### PR TITLE
fix for #148

### DIFF
--- a/bigip/resource_bigip_ltm_node.go
+++ b/bigip/resource_bigip_ltm_node.go
@@ -63,12 +63,11 @@ func resourceBigipLtmNode() *schema.Resource {
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "Test-Node",
+				Default:  "",
 			},
 			"state": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "user-up",
 				Description: "Marks the node up or down. The default value is user-up.",
 			},
 			"fqdn": {
@@ -210,6 +209,7 @@ func resourceBigipLtmNodeRead(d *schema.ResourceData, meta interface{}) error {
 
 	//d.Set("state", node.State)
 	d.Set("connection_limit", node.ConnectionLimit)
+	d.Set("description", node.Description)
 	d.Set("dynamic_ratio", node.DynamicRatio)
 	d.Set("fqdn.0.interval", node.FQDN.Interval)
 	d.Set("fqdn.0.downinterval", node.FQDN.DownInterval)

--- a/bigip/resource_bigip_ltm_node_test.go
+++ b/bigip/resource_bigip_ltm_node_test.go
@@ -20,6 +20,7 @@ resource "bigip_ltm_node" "test-node" {
 	dynamic_ratio = "1"
 	monitor = "/Common/icmp"
 	rate_limit = "disabled"
+	state = "user-up"
 }
 `
 var TEST_FQDN_NODE_RESOURCE = `
@@ -31,6 +32,7 @@ resource "bigip_ltm_node" "test-fqdn-node" {
 	monitor = "default"
 	rate_limit = "disabled"
 	fqdn { interval = "3000"}
+	state = "user-up"
 }
 `
 
@@ -50,7 +52,7 @@ func TestAccBigipLtmNode_create(t *testing.T) {
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "address", "192.168.30.1"),
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "connection_limit", "0"),
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "dynamic_ratio", "1"),
-					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "description", "Test-Node"),
+					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "description", ""),
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "monitor", "/Common/icmp"),
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "rate_limit", "disabled"),
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "state", "user-up"),
@@ -74,7 +76,7 @@ func TestAccBigipLtmNode_create(t *testing.T) {
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-fqdn-node", "address", "f5.com"),
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-fqdn-node", "connection_limit", "0"),
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-fqdn-node", "dynamic_ratio", "1"),
-					resource.TestCheckResourceAttr("bigip_ltm_node.test-fqdn-node", "description", "Test-Node"),
+					resource.TestCheckResourceAttr("bigip_ltm_node.test-fqdn-node", "description", ""),
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-fqdn-node", "monitor", "default"),
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-fqdn-node", "rate_limit", "disabled"),
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-fqdn-node", "state", "user-up"),


### PR DESCRIPTION
```

=== RUN   TestAccBigipLtmNode_create
--- PASS: TestAccBigipLtmNode_create (6.09s)
=== RUN   TestAccBigipLtmNode_import
--- PASS: TestAccBigipLtmNode_import (6.05s)
=== RUN   TestAccBigipLtmNodeInvalid
--- PASS: TestAccBigipLtmNodeInvalid (0.01s)
=== RUN   TestAccBigipLtmNodeCreate
--- PASS: TestAccBigipLtmNodeCreate (0.06s)
```