### PR TITLE
Fixed as3 tenant delete Issue

### DIFF
--- a/bigip/resource_bigip_as3.go
+++ b/bigip/resource_bigip_as3.go
@@ -37,10 +37,11 @@ func resourceBigipAs3() *schema.Resource {
 				Description:  "AS3 json",
 				ValidateFunc: validation.ValidateJsonString,
 			},
-			"config_name": {
+			"tenant_name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "unique identifier for AS3 resource",
+				ForceNew:    true,
+				Description: "Name of Tenant",
 			},
 		},
 	}
@@ -50,7 +51,7 @@ func resourceBigipAs3Create(d *schema.ResourceData, meta interface{}) error {
 	client_bigip := meta.(*bigip.BigIP)
 
 	as3_json := d.Get("as3_json").(string)
-	name := d.Get("config_name").(string)
+	name := d.Get("tenant_name").(string)
 	log.Printf("[INFO] Creating as3 config in bigip:%s", as3_json)
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
@@ -163,11 +164,12 @@ func resourceBigipAs3Update(d *schema.ResourceData, meta interface{}) error {
 func resourceBigipAs3Delete(d *schema.ResourceData, meta interface{}) error {
 	client_bigip := meta.(*bigip.BigIP)
 	log.Printf("[INFO] Deleting As3 config")
+	name := d.Get("tenant_name").(string)
 
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
 	client := &http.Client{Transport: tr}
-	url := client_bigip.Host + "/mgmt/shared/appsvcs/declare/"
+	url := client_bigip.Host + "/mgmt/shared/appsvcs/declare/" + name
 	req, err := http.NewRequest("DELETE", url, nil)
 
 	if err != nil {

--- a/examples/as3/as3_example.tmpl
+++ b/examples/as3/as3_example.tmpl
@@ -1,0 +1,43 @@
+ {
+     "class": "AS3",
+     "action": "deploy",
+     "persist": true,
+     "declaration": {
+         "class": "ADC",
+         "schemaVersion": "3.0.0",
+         "id": "example-declaration-01",
+         "label": "Sample 1",
+         "remark": "Simple HTTP application with round robin pool",
+         ${tenant_name}: {
+             "class": "Tenant",
+             "defaultRouteDomain": 0,
+             "Application_1": {
+                 "class": "Application",
+                 "template": "http",
+             "serviceMain": {
+                 "class": "Service_HTTP",
+                 "virtualAddresses": [
+                     "10.0.2.10"
+                 ],
+                 "pool": "web_pool"
+                 },
+                 "web_pool": {
+                     "class": "Pool",
+                     "monitors": [
+                         "http"
+                     ],
+                     "members": [
+                         {
+                             "servicePort": 80,
+                             "serverAddresses": [
+                                 "192.0.1.100",
+                                 "192.0.1.110"
+                             ]
+                         }
+                     ]
+                 }
+             }
+         }
+     }
+ }
+


### PR DESCRIPTION
Test Results:
```
=== RUN   TestAccProvider
--- PASS: TestAccProvider (0.00s)
=== RUN   TestAccBigipAs3_create
--- PASS: TestAccBigipAs3_create (26.29s)
=== RUN   TestAccBigipAs3_badJSON
--- PASS: TestAccBigipAs3_badJSON (0.02s)
=== RUN   TestAccBigipCmDevice_create
=== RUN   TestAccBigipCmDevice_import
--- PASS: TestAccBigipCmDevice_import (0.98s)
=== RUN   TestAccBigipCmDevicegroup_create
--- PASS: TestAccBigipCmDevicegroup_create (2.70s)
=== RUN   TestAccBigipCmDevicegroup_import
--- PASS: TestAccBigipCmDevicegroup_import (1.35s)
=== RUN   TestAccBigipLtmDataGroup_create
--- PASS: TestAccBigipLtmDataGroup_create (2.55s)
=== RUN   TestAccBigipLtmDataGroup_import
--- PASS: TestAccBigipLtmDataGroup_import (2.71s)
=== RUN   TestAccBigipLtmIRule_create
--- PASS: TestAccBigipLtmIRule_create (1.10s)
=== RUN   TestAccBigipLtmIRule_import
--- PASS: TestAccBigipLtmIRule_import (0.64s)
=== RUN   TestAccBigipLtmMonitor_create
--- PASS: TestAccBigipLtmMonitor_create (7.45s)
=== RUN   TestAccBigipLtmMonitor_import
--- PASS: TestAccBigipLtmMonitor_import (1.70s)
=== RUN   TestAccBigipLtmNode_create
--- PASS: TestAccBigipLtmNode_create (1.54s)
=== RUN   TestAccBigipLtmNode_import
--- PASS: TestAccBigipLtmNode_import (1.57s)
=== RUN   TestAccBigipLtmNodeInvalid
--- PASS: TestAccBigipLtmNodeInvalid (0.02s)
=== RUN   TestAccBigipLtmNodeCreate
--- PASS: TestAccBigipLtmNodeCreate (0.10s)
=== RUN   TestAccBigipLtmPersistenceProfileCookieCreate
--- PASS: TestAccBigipLtmPersistenceProfileCookieCreate (0.93s)
=== RUN   TestAccBigipLtmPersistenceProfileCookieImport
--- PASS: TestAccBigipLtmPersistenceProfileCookieImport (0.81s)
=== RUN   TestAccBigipLtmPersistenceProfileDstAddrCreate
--- PASS: TestAccBigipLtmPersistenceProfileDstAddrCreate (1.00s)
=== RUN   TestAccBigipLtmPersistenceProfileDstAddrImport
--- PASS: TestAccBigipLtmPersistenceProfileDstAddrImport (0.67s)
=== RUN   TestAccBigipLtmPersistenceProfileSrcAddrCreate
--- PASS: TestAccBigipLtmPersistenceProfileSrcAddrCreate (0.81s)
=== RUN   TestAccBigipLtmPersistenceProfileSrcAddrImport
--- PASS: TestAccBigipLtmPersistenceProfileSrcAddrImport (0.88s)
=== RUN   TestAccBigipLtmPersistenceProfileSSLCreate
--- PASS: TestAccBigipLtmPersistenceProfileSSLCreate (0.83s)
=== RUN   TestAccBigipLtmPersistenceProfileSSLImport
--- PASS: TestAccBigipLtmPersistenceProfileSSLImport (0.92s)
=== RUN   TestAccBigipLtmPolicy_create
--- PASS: TestAccBigipLtmPolicy_create (2.00s)
=== RUN   TestAccBigipLtmPolicy_import
--- PASS: TestAccBigipLtmPolicy_import (1.73s)
=== RUN   TestAccBigipLtmPool_create
--- PASS: TestAccBigipLtmPool_create (0.80s)
=== RUN   TestAccBigipLtmPool_import
--- PASS: TestAccBigipLtmPool_import (0.84s)
=== RUN   TestAccBigipLtmfasthttp_create
--- PASS: TestAccBigipLtmfasthttp_create (0.70s)
=== RUN   TestAccBigipLtmProfilefasthttp_import
--- PASS: TestAccBigipLtmProfilefasthttp_import (1.23s)
=== RUN   TestAccBigipLtmProfileFastl4_create
--- PASS: TestAccBigipLtmProfileFastl4_create (0.56s)
=== RUN   TestAccBigipLtmProfileFastl4_import
--- PASS: TestAccBigipLtmProfileFastl4_import (1.08s)
=== RUN   TestAccBigipLtmProfileHttp2_create
--- PASS: TestAccBigipLtmProfileHttp2_create (0.79s)
=== RUN   TestAccBigipLtmProfileHttp2_modify
--- PASS: TestAccBigipLtmProfileHttp2_modify (1.07s)
=== RUN   TestAccBigipLtmProfileHttp2_import
--- PASS: TestAccBigipLtmProfileHttp2_import (0.59s)
=== RUN   TestAccBigipLtmProfilehttp_create
--- PASS: TestAccBigipLtmProfilehttp_create (0.66s)
=== RUN   TestAccBigipLtmProfilehttp_import
--- PASS: TestAccBigipLtmProfilehttp_import (0.75s)
=== RUN   TestAccBigipLtmProfileHttpcompress_create
--- PASS: TestAccBigipLtmProfileHttpcompress_create (0.62s)
=== RUN   TestAccBigipLtmProfileHttpcompress_import
--- PASS: TestAccBigipLtmProfileHttpcompress_import (0.50s)
=== RUN   TestAccBigipLtmProfileoneconnect_create
--- PASS: TestAccBigipLtmProfileoneconnect_create (0.59s)
=== RUN   TestAccBigipLtmProfileoneconnect_import
--- PASS: TestAccBigipLtmProfileoneconnect_import (0.48s)
=== RUN   TestAccBigipLtmProfileClientSsl_create
--- PASS: TestAccBigipLtmProfileClientSsl_create (0.94s)
=== RUN   TestAccBigipLtmProfileClientSsl_import
--- PASS: TestAccBigipLtmProfileClientSsl_import (0.62s)
=== RUN   TestAccBigipLtmProfileServerSsl_create
--- PASS: TestAccBigipLtmProfileServerSsl_create (0.65s)
=== RUN   TestAccBigipLtmProfileServerSsl_import
--- PASS: TestAccBigipLtmProfileServerSsl_import (0.58s)
=== RUN   TestAccBigipLtmProfileTcp_create
--- PASS: TestAccBigipLtmProfileTcp_create (0.59s)
=== RUN   TestAccBigipLtmProfileTcp_import
--- PASS: TestAccBigipLtmProfileTcp_import (0.51s)
=== RUN   TestAccBigipLtmsnat_create
--- PASS: TestAccBigipLtmsnat_create (0.98s)
=== RUN   TestAccBigipLtmsnat_import
--- PASS: TestAccBigipLtmsnat_import (0.63s)
=== RUN   TestAccBigipLtmsnatpool_create
--- PASS: TestAccBigipLtmsnatpool_create (0.50s)
=== RUN   TestAccBigipLtmsnatpool_import
--- PASS: TestAccBigipLtmsnatpool_import (0.58s)
=== RUN   TestAccBigipLtmVA_create
--- PASS: TestAccBigipLtmVA_create (0.60s)
=== RUN   TestAccBigipLtmVA_import
--- PASS: TestAccBigipLtmVA_import (0.66s)
=== RUN   TestAccBigipLtmVS_create
--- PASS: TestAccBigipLtmVS_create (2.13s)
=== RUN   TestAccBigipLtmVS_create_Defaultstate
--- PASS: TestAccBigipLtmVS_create_Defaultstate (0.79s)
=== RUN   TestAccBigipLtmVS_Modify_stateDisabledtoEnabled
--- PASS: TestAccBigipLtmVS_Modify_stateDisabledtoEnabled (1.40s)
=== RUN   TestAccBigipLtmVS_Modify_stateEnabledtoDisabled
--- PASS: TestAccBigipLtmVS_Modify_stateEnabledtoDisabled (1.40s)
=== RUN   TestAccBigipLtmVS_import
--- PASS: TestAccBigipLtmVS_import (1.62s)
=== RUN   TestAccBigipNetroute_create
--- PASS: TestAccBigipNetroute_create (1.32s)
=== RUN   TestAccBigipNetroute_import
--- PASS: TestAccBigipNetroute_import (0.91s)
=== RUN   TestAccBigipNetselfip_create
--- PASS: TestAccBigipNetselfip_create (1.05s)
=== RUN   TestAccBigipNetselfip_import
--- PASS: TestAccBigipNetselfip_import (1.97s)
=== RUN   TestAccBigipNetvlan_create
--- PASS: TestAccBigipNetvlan_create (2.55s)
=== RUN   TestAccBigipNetvlan_import
--- PASS: TestAccBigipNetvlan_import (2.55s)
=== RUN   TestAccSslCertificateImportToBigip
--- PASS: TestAccSslCertificateImportToBigip (1.06s)
=== RUN   TestAccSslKeyImportToBigip
--- PASS: TestAccSslKeyImportToBigip (0.92s)
=== RUN   TestAccBigipSysdns_import
--- PASS: TestAccBigipSysdns_import (62.78s)
=== RUN   TestAccBigipSysIapp_create
--- PASS: TestAccBigipSysIapp_create (3.98s)
=== RUN   TestAccBigipSysIapp_import
--- PASS: TestAccBigipSysIapp_import (2.84s)
=== RUN   TestAccBigipSysNtp_create
--- PASS: TestAccBigipSysNtp_create (1.47s)
=== RUN   TestAccBigipSysNtp_import
--- PASS: TestAccBigipSysNtp_import (1.45s)
=== RUN   TestAccBigipSysNtpInvalid
--- PASS: TestAccBigipSysNtpInvalid (0.01s)
=== RUN   TestAccBigipSysProvision_create
--- PASS: TestAccBigipSysProvision_create (2.22s)
=== RUN   TestAccBigipSysProvision_import
--- PASS: TestAccBigipSysProvision_import (0.36s)
=== RUN   TestAccBigipSyssnmp_create
--- PASS: TestAccBigipSyssnmp_create (1.82s)
=== RUN   TestAccBigipSyssnmp_import
--- PASS: TestAccBigipSyssnmp_import (1.46s)
PASS
PASS	github.com/terraform-providers/terraform-provider-bigip/bigip	234.043s

```