### PR TITLE
fix for Unable to modify/update data group #248

### DIFF
--- a/vendor/github.com/f5devcentral/go-bigip/ltm.go
+++ b/vendor/github.com/f5devcentral/go-bigip/ltm.go
@@ -2057,14 +2057,11 @@ func (b *BigIP) DeleteInternalDataGroup(name string) error {
 	return b.delete(uriLtm, uriDatagroup, uriInternal, name)
 }
 
-// Modify a named internal data group, REPLACING all the records
-func (b *BigIP) ModifyInternalDataGroupRecords(name, dgtype string, records []DataGroupRecord) error {
-	config := &DataGroup{
-		Records: records,
-		Type:    dgtype,
-	}
-	return b.put(config, uriLtm, uriDatagroup, uriInternal, name)
+func (b *BigIP) ModifyInternalDataGroupRecords(config *DataGroup) error {
+	return b.put(config, uriLtm, uriDatagroup, uriInternal, config.Name)
+
 }
+
 
 // Get an internal data group by name, returns nil if the data group does not exist
 func (b *BigIP) GetInternalDataGroup(name string) (*DataGroup, error) {

--- a/vendor/github.com/f5devcentral/go-bigip/sys.go
+++ b/vendor/github.com/f5devcentral/go-bigip/sys.go
@@ -15,6 +15,28 @@ import (
 	"log"
 )
 
+type Version struct {
+	Kind     string `json:"kind,omitempty"`
+	SelfLink string `json:"selfLink,omitempty"`
+	Entries  struct {
+		HTTPSLocalhostMgmtTmCliVersion0 struct {
+			NestedStats struct {
+				Entries struct {
+					Active struct {
+						Description string `json:"description"`
+					} `json:"active,omitempty"`
+					Latest struct {
+						Description string `json:"description"`
+					} `json:"latest,omitempty"`
+					Supported struct {
+						Description string `json:"description"`
+					} `json:"supported,omitempty"`
+				} `json:"entries,omitempty"`
+			} `json:"nestedStats,omitempty"`
+		} `json:"https://localhost/mgmt/tm/cli/version/0,omitempty"`
+	} `json:"entries,omitempty"`
+}
+
 type NTPs struct {
 	NTPs []NTP `json:"items"`
 }
@@ -214,6 +236,9 @@ func (p *LogPublisher) UnmarshalJSON(b []byte) error {
 
 const (
 	uriSys             = "sys"
+        uriTm              = "tm"
+        uriCli             = "cli"
+	uriVersion         = "version"
 	uriNtp             = "ntp"
 	uriDNS             = "dns"
 	uriProvision       = "provision"
@@ -485,6 +510,16 @@ func (b *BigIP) NTPs() (*NTP, error) {
 		return nil, err
 	}
 	return &ntp, nil
+}
+
+func (b *BigIP) BigipVersion() (*Version, error) {
+        var  bigipversion Version
+        err, _ := b.getForEntity(&bigipversion, uriMgmt, uriTm, uriCli, uriVersion)
+
+        if err != nil {
+                return nil, err
+        }
+        return &bigipversion, nil
 }
 
 func (b *BigIP) CreateDNS(description string, nameservers []string, numberofdots int, search []string) error {


### PR DESCRIPTION
To update data groups "type" is needed from bigip version 14 onwards.
Check bigip version before update call , if it is bigip version 12,13 don't send type in api request call, and if it is bigip version 14 + , send type in api request.

Tested in bigip versions 12,13,14.