### PR TITLE
Update module path from terraform-providers to F5Networks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@
 //This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 //If a copy of the MPL was not distributed with this file,You can obtain one at https://mozilla.org/MPL/2.0/.
 
-module github.com/terraform-providers/terraform-provider-bigip
+module github.com/F5Networks/terraform-provider-bigip
 
 require (
 	github.com/f5devcentral/go-bigip v0.0.0-20200902132350-cf5379c78bac

--- a/main.go
+++ b/main.go
@@ -7,8 +7,8 @@ If a copy of the MPL was not distributed with this file,You can obtain one at ht
 package main
 
 import (
+	"github.com/F5Networks/terraform-provider-bigip/bigip"
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/terraform-providers/terraform-provider-bigip/bigip"
 )
 
 func main() {


### PR DESCRIPTION
Now that the repo has changed from the terraform-providers org to
the F5Networks org, the module path should be updated.

This is in line with other providers who have moved in the same
way

e.g https://github.com/digitalocean/terraform-provider-digitalocean/pull/463