### PR TITLE
Typo in the naming of the gw argument

### DIFF
--- a/docs/resources/bigip_net_route.md
+++ b/docs/resources/bigip_net_route.md
@@ -31,4 +31,4 @@ resource "bigip_net_route" "route2" {
 
 * `network` - (Optional) The destination subnet and netmask for the route.
 
-* `network` - (Optional) Specifies a gateway address for the route.
+* `gw` - (Optional) Specifies a gateway address for the route.


### PR DESCRIPTION
The network parameter is specified twice. Annoyed me so I went in and fixed it.
Not sure this is up to the standards on how to contribute to this project. But I guess we'll see about that.