### PR TITLE
Add environment variable references to provider documentation

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -25,11 +25,11 @@ provider "bigip" {
 
 ## Reference
 
-- `address` - (Required) Address of the device
-- `username` - (Required) Username for authentication
-- `password` - (Required) Password for authentication
-- `token_auth` - (Optional, Default=false) Enable to use an external authentication source (LDAP, TACACS, etc)
-- `login_ref` - (Optional, Default="tmos") Login reference for token authentication (see BIG-IP REST docs for details)
+- `address` - (Required) Domain name or IP address of the device. May be set via the `BIGIP_HOST` environment variable.
+- `username` - (Required) Username for authentication. May be set via the `BIGIP_USER` environment variable.
+- `password` - (Required) Password for authentication. May be set via the `BIGIP_PASSWORD` environment variable.
+- `token_auth` - (Optional, Default=false) Enable to use an external authentication source (LDAP, TACACS, etc). May be set via the `BIGIP_TOKEN_AUTH` environment variable.
+- `login_ref` - (Optional, Default="tmos") Login reference for token authentication (see BIG-IP REST docs for details). May be set via the `BIGIP_LOGIN_REF` environment variable.
 
 ### Note
 The F5 BIG-IP provider gathers non-identifiable usage data for the purposes of improving the product as outlined in the end user license agreement for BIG-IP. To opt out of data collection, use the following:

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -16,10 +16,14 @@ This provider uses the iControlREST API. All the resources are validated with Bi
 ## Example
 
 ```
+variable hostname {}
+variable username {}
+variable password {}
+
 provider "bigip" {
-  address = "${var.url}"
-  username = "${var.username}"
-  password = "${var.password}"
+  address = var.hostname
+  username = var.username
+  password = var.password
 }
 ```
 


### PR DESCRIPTION
Documented the [environment variables](https://github.com/F5Networks/terraform-provider-bigip/blob/48eac3ab7ef32a56205d793958aca00aececc17d/bigip/provider.go#L23-L66) that can be used to configure the BIGIP provider.