### PR TITLE
fixes #428

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ examples1
 # Allow
 # Keep windows files with windows line endings
 *.winfile eol=crlf
+build

--- a/bigip/resource_bigip_ssl_certificate.go
+++ b/bigip/resource_bigip_ssl_certificate.go
@@ -1,10 +1,12 @@
 package bigip
 
 import (
+	"errors"
 	"fmt"
 	"github.com/f5devcentral/go-bigip"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"log"
+	"strings"
 )
 
 func resourceBigipSslCertificate() *schema.Resource {
@@ -64,7 +66,18 @@ func resourceBigipSslCertificateRead(d *schema.ResourceData, meta interface{}) e
 	name := d.Id()
 	log.Println("[INFO] Reading Certificate : " + name)
 	partition := d.Get("partition").(string)
-	name = "/" + partition + "/" + name
+
+	if partition == "" {
+		if strings.HasPrefix(name, "/") != true {
+			err := errors.New("the name must be in full_path format when partition is not specified")
+			fmt.Print(err)
+		}
+	} else {
+		if strings.HasPrefix(name, "/") != true {
+			name = "/" + partition + "/" + name
+		}
+	}
+
 	certificate, err := client.GetCertificate(name)
 	log.Printf("[INFO] Certificate content:%+v", certificate)
 	d.Set("name", certificate.Name)
@@ -81,7 +94,16 @@ func resourceBigipSslCertificateExists(d *schema.ResourceData, meta interface{})
 	log.Println("[INFO] Checking certificate " + name + " exists.")
 	partition := d.Get("partition").(string)
 
-	name = "/" + partition + "/" + name
+	if partition == "" {
+		if strings.HasPrefix(name, "/") != true {
+			err := errors.New("the name must be in full_path format when partition is not specified")
+			fmt.Print(err)
+		}
+	} else {
+		if strings.HasPrefix(name, "/") != true {
+			name = "/" + partition + "/" + name
+		}
+	}
 	certificate, err := client.GetCertificate(name)
 	if err != nil {
 		log.Printf("[ERROR] Unable to Retrieve certificate   (%s) (%v) ", name, err)

--- a/bigip/resource_bigip_ssl_key.go
+++ b/bigip/resource_bigip_ssl_key.go
@@ -1,10 +1,12 @@
 package bigip
 
 import (
+	"errors"
 	"fmt"
 	"github.com/f5devcentral/go-bigip"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"log"
+	"strings"
 )
 
 func resourceBigipSslKey() *schema.Resource {
@@ -70,7 +72,16 @@ func resourceBigipSslKeyRead(d *schema.ResourceData, meta interface{}) error {
 		name = name + ".key"
 	}*/
 	partition := d.Get("partition").(string)
-	name = "/" + partition + "/" + name
+	if partition == "" {
+		if strings.HasPrefix(name, "/") != true {
+			err := errors.New("the name must be in full_path format when partition is not specified")
+			fmt.Print(err)
+		}
+	} else {
+		if strings.HasPrefix(name, "/") != true {
+			name = "/" + partition + "/" + name
+		}
+	}
 	certkey, err := client.GetKey(name)
 	log.Printf("[INFO] SSL key content:%+v", certkey)
 	d.Set("name", certkey.Name)
@@ -89,7 +100,16 @@ func resourceBigipSslKeyExists(d *schema.ResourceData, meta interface{}) (bool, 
 		name = name + ".key"
 	}*/
 	partition := d.Get("partition").(string)
-	name = "/" + partition + "/" + name
+	if partition == "" {
+		if strings.HasPrefix(name, "/") != true {
+			err := errors.New("the name must be in full_path format when partition is not specified")
+			fmt.Print(err)
+		}
+	} else {
+		if strings.HasPrefix(name, "/") != true {
+			name = "/" + partition + "/" + name
+		}
+	}
 	certkey, err := client.GetKey(name)
 	if err != nil {
 		log.Printf("[ERROR] Unable to Retrieve certificate key (%s) (%v) ", name, err)

--- a/docs/resources/bigip_ssl_certificate.md
+++ b/docs/resources/bigip_ssl_certificate.md
@@ -32,4 +32,4 @@ resource "bigip_ssl_certificate" "test-cert" {
 
 * `content` - (Required) Content of certificate on Local Disk,path of SSL certificate will be provided to terraform `file` function 
 
-* `partition` - (Required) Partition on to SSL Certificate to be imported
+* `partition` - Partition on to SSL Certificate to be imported. The parameter is not required when running terraform import operation. In such case the name must be provided in full_path format.

--- a/docs/resources/bigip_ssl_key.md
+++ b/docs/resources/bigip_ssl_key.md
@@ -32,4 +32,4 @@ resource "bigip_ssl_key" "test-key" {
 
 * `content` - (Required) Content of certificate key on Local Disk,path of SSL certificate key will be provided to terraform `file` function 
 
-* `partition` - (Required) Partition on to SSL Certificate key to be imported
+* `partition` - Partition on to SSL Certificate key to be imported. The parameter is not required when running terraform import operation. In such case the name must be provided in full_path format.

--- a/website/docs/r/bigip_ssl_certificate.html.markdown
+++ b/website/docs/r/bigip_ssl_certificate.html.markdown
@@ -32,4 +32,4 @@ resource "bigip_ssl_certificate" "test-cert" {
 
 * `content` - (Required) Content of certificate on Local Disk,path of SSL certificate will be provided to terraform `file` function 
 
-* `partition` - (Required) Partition on to SSL Certificate to be imported
+* `partition` - Partition on to SSL Certificate to be imported. The parameter is not required when running terraform import operation. In such case the name must be provided in full_path format.

--- a/website/docs/r/bigip_ssl_key.html.markdown
+++ b/website/docs/r/bigip_ssl_key.html.markdown
@@ -32,4 +32,4 @@ resource "bigip_ssl_key" "test-key" {
 
 * `content` - (Required) Content of certificate key on Local Disk,path of SSL certificate key will be provided to terraform `file` function 
 
-* `partition` - (Required) Partition on to SSL Certificate key to be imported
+* `partition` - Partition on to SSL Certificate key to be imported. The parameter is not required when running terraform import operation. In such case the name must be provided in full_path format.


### PR DESCRIPTION
adds terraform import fix, to allow names in full_path format for ssl_certificate and ssl_key resources

fixes #428