### PR TITLE
Add auth token config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,14 @@ Copyright 2014-2020 F5 Networks Inc.
 
 ### F5 Networks Contributor License Agreement
 
-[Terraform F5 Contributor License Agreement.pdf](https://github.com/F5Networks/terraform-provider-bigip/blob/profile_detatch_issue/F5_Contributor_License_Agreement.pdf)
+[Terraform F5 Contributor License Agreement.pdf](F5_Contributor_License_Agreement.pdf)
 
-Before you start contributing to any project sponsored by F5 Networks, Inc. (F5) on GitHub, you will need to sign a Contributor License Agreement (CLA).  
+Before you start contributing to any project sponsored by F5 Networks, Inc. (F5) on GitHub, you will need to sign a Contributor License Agreement (CLA).
 
-If you are signing as an individual, we recommend that you talk to your employer (if applicable) before signing the CLA since some employment agreements may have restrictions on your contributions to other projects. Otherwise by submitting a CLA you represent that you are legally entitled to grant the licenses recited therein.  
+If you are signing as an individual, we recommend that you talk to your employer (if applicable) before signing the CLA since some employment agreements may have restrictions on your contributions to other projects. Otherwise by submitting a CLA you represent that you are legally entitled to grant the licenses recited therein.
 
-If your employer has rights to intellectual property that you create, such as your contributions, you represent that you have received permission to make contributions on behalf of that employer, that your employer has waived such rights for your contributions, or that your employer has executed a separate CLA with F5.   
+If your employer has rights to intellectual property that you create, such as your contributions, you represent that you have received permission to make contributions on behalf of that employer, that your employer has waived such rights for your contributions, or that your employer has executed a separate CLA with F5.
 
-If you are signing on behalf of a company, you represent that you are legally entitled to grant the license recited therein. You represent further that each employee of the entity that submits contributions is authorized to submit such contributions on behalf of the entity pursuant to the CLA. 
+If you are signing on behalf of a company, you represent that you are legally entitled to grant the license recited therein. You represent further that each employee of the entity that submits contributions is authorized to submit such contributions on behalf of the entity pursuant to the CLA.
 
 

--- a/bigip/provider.go
+++ b/bigip/provider.go
@@ -42,8 +42,14 @@ func Provider() terraform.ResourceProvider {
 			"password": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "The user's password",
+				Description: "The user's password. Leave empty if using token_value",
 				DefaultFunc: schema.EnvDefaultFunc("BIGIP_PASSWORD", nil),
+			},
+			"token_value": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A token generated outside the provider, in place of password",
+				DefaultFunc: schema.EnvDefaultFunc("BIGIP_TOKEN_VALUE", nil),
 			},
 			"token_auth": {
 				Type:        schema.TypeBool,
@@ -147,6 +153,7 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 		Port:     d.Get("port").(string),
 		Username: d.Get("username").(string),
 		Password: d.Get("password").(string),
+		Token:    d.Get("token_value").(string),
 	}
 	if d.Get("token_auth").(bool) {
 		config.LoginReference = d.Get("login_ref").(string)

--- a/bigip/provider_test.go
+++ b/bigip/provider_test.go
@@ -7,10 +7,11 @@ If a copy of the MPL was not distributed with this file,You can obtain one at ht
 package bigip
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"os"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 var TEST_PARTITION = "Common"
@@ -39,7 +40,7 @@ func TestAccProvider(t *testing.T) {
 }
 
 func testAcctPreCheck(t *testing.T) {
-	if os.Getenv("BIGIP_TOKEN_AUTH") != "" && os.Getenv("BIGIP_LOGIN_REF") != "" {
+	if os.Getenv("BIGIP_TOKEN_VALUE") != "" || (os.Getenv("BIGIP_TOKEN_AUTH") != "" && os.Getenv("BIGIP_LOGIN_REF") != "") {
 		return
 	}
 	for _, s := range [...]string{"BIGIP_HOST", "BIGIP_USER", "BIGIP_PASSWORD"} {


### PR DESCRIPTION
This is a rough draft of allowing the provider to accept a token instead
of using username and password. The intention is that the user would
retrieve an auth token and possibly extend the expiration, outside of
Terraform. This allows for multiple providers to use the same token to
avoid exhausting the number of tokens from the BigIP.

This addresses #401