### PR TITLE
Fix for As3 target token issue

### DIFF
--- a/vendor/github.com/f5devcentral/go-bigip/as3bigip.go
+++ b/vendor/github.com/f5devcentral/go-bigip/as3bigip.go
@@ -426,12 +426,14 @@ func (b *BigIP) AddTeemAgent(body interface{}) (string, error) {
 	//userAgent, err := getVersion("/usr/local/bin/terraform")
 	//log.Printf("[DEBUG] Terraform version:%+v", userAgent)
 	res1 := strings.Split(as3ver.Version, ".")
-	for _, value := range jsonRef {
+	for key, value := range jsonRef {
+	    if key == "declaration" {
 		if rec, ok := value.(map[string]interface{}); ok {
 			if intConvert(res1[0]) > 3 || intConvert(res1[1]) >= 18 {
 				rec["controls"] = map[string]interface{}{"class": "Controls", "userAgent": b.UserAgent}
 			}
 		}
+            }
 	}
 	jsonData, err := json.Marshal(jsonRef)
 	if err != nil {


### PR DESCRIPTION
Fix for #511 

acceptance tests:
HYD-ML-00064439:terraform-provider-bigip papineni$ BIGIP_USER=xxxxx BIGIP_PASSWORD=xxxxx BIGIP_HOST=x.x.x.x TF_ACC=1 go test ./bigip/ -v -run=TestAccBigipAs3*
=== RUN   TestAccBigipAs3_create_SingleTenant
--- PASS: TestAccBigipAs3_create_SingleTenant (30.40s)
=== RUN   TestAccBigipAs3_create_MultiTenants
--- PASS: TestAccBigipAs3_create_MultiTenants (29.78s)
=== RUN   TestAccBigipAs3_create_PartialSuccess
--- PASS: TestAccBigipAs3_create_PartialSuccess (32.80s)
=== RUN   TestAccBigipAs3_addTenantFilter
--- PASS: TestAccBigipAs3_addTenantFilter (31.93s)
=== RUN   TestAccBigipAs3_update_addTenant
--- PASS: TestAccBigipAs3_update_addTenant (62.07s)
=== RUN   TestAccBigipAs3_update_deleteTenant
--- PASS: TestAccBigipAs3_update_deleteTenant (59.80s)
=== RUN   TestAccBigipAs3_update_config
--- PASS: TestAccBigipAs3_update_config (50.37s)
=== RUN   TestAccBigipAs3_import_SingleTenant
--- PASS: TestAccBigipAs3_import_SingleTenant (30.33s)
=== RUN   TestAccBigipAs3_import_MultiTenants
--- PASS: TestAccBigipAs3_import_MultiTenants (31.29s)
=== RUN   TestAccBigipAs3_badJSON
--- PASS: TestAccBigipAs3_badJSON (0.02s)
PASS
ok  	github.com/F5Networks/terraform-provider-bigip/bigip	359.852s
HYD-ML-00064439:terraform-provider-bigip papineni$ 
