### PR TITLE
bigip_ltm_node: adding session param 

### DIFF
--- a/bigip/datasource_bigip_ltm_node.go
+++ b/bigip/datasource_bigip_ltm_node.go
@@ -7,10 +7,11 @@ package bigip
 
 import (
 	"fmt"
-	"github.com/f5devcentral/go-bigip"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"log"
 	"regexp"
+
+	"github.com/f5devcentral/go-bigip"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func dataSourceBigipLtmNode() *schema.Resource {
@@ -66,6 +67,11 @@ func dataSourceBigipLtmNode() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The current state of the node.",
+			},
+			"session": {
+				Type:        schema.TypeString,
+				Description: "Enables or disables the node for new sessions.",
+				Computed:    true,
 			},
 			"fqdn": {
 				Type:     schema.TypeList,
@@ -146,6 +152,7 @@ func dataSourceBigipLtmNodeRead(d *schema.ResourceData, meta interface{}) error 
 	_ = d.Set("rate_limit", node.RateLimit)
 	_ = d.Set("ratio", node.Ratio)
 	_ = d.Set("state", node.State)
+	_ = d.Set("session", node.Session)
 
 	var fqdn []map[string]interface{}
 

--- a/bigip/resource_bigip_ltm_node_test.go
+++ b/bigip/resource_bigip_ltm_node_test.go
@@ -78,6 +78,7 @@ func TestAccBigipLtmNode_create(t *testing.T) {
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "monitor", "/Common/icmp"),
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "rate_limit", "disabled"),
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "state", "user-up"),
+					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "session", "user-enabled"),
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "ratio", "91"),
 				),
 			},

--- a/docs/resources/bigip_ltm_node.md
+++ b/docs/resources/bigip_ltm_node.md
@@ -50,6 +50,8 @@ resource "bigip_ltm_node" "node" {
 
 * `state` - (Optional) Default is "user-up" you can set to "user-down" if you want to disable
 
+* `session` - (Optional) Enables or disables the node for new sessions. Can be set to `user-enabled` or `user-disabled`. (Default: `user-enabled`).
+
 * Below attributes needs to be configured under fqdn option.
 
 * `interval` - (Optional) Specifies the amount of time before sending the next DNS query. Default is 3600. This needs to be specified inside the fqdn (fully qualified domain name).


### PR DESCRIPTION
Adding `session` param to `bigip_ltm_node` resource and data source

Helps in configuring connection draining
