### PR TITLE
Add full_path to datasource_bigip_ltm_node

### DIFF
--- a/bigip/datasource_bigip_ltm_node.go
+++ b/bigip/datasource_bigip_ltm_node.go
@@ -28,6 +28,11 @@ func dataSourceBigipLtmNode() *schema.Resource {
 				Required:    true,
 				Description: "Partition of resource group",
 			},
+			"full_path": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Full path of the node (partition and name)",
+			},
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -146,6 +151,7 @@ func dataSourceBigipLtmNodeRead(d *schema.ResourceData, meta interface{}) error 
 
 	_ = d.Set("name", node.Name)
 	_ = d.Set("partition", node.Partition)
+	_ = d.Set("full_path", node.FullPath)
 	_ = d.Set("connection_limit", node.ConnectionLimit)
 	_ = d.Set("dynamic_ratio", node.DynamicRatio)
 	_ = d.Set("monitor", node.Monitor)

--- a/website/docs/d/bigip_ltm_node.html.markdown
+++ b/website/docs/d/bigip_ltm_node.html.markdown
@@ -9,8 +9,8 @@ description: |-
 # bigip\_ltm\_node
 
 Use this data source (`bigip_ltm_node`) to get the ltm node details available on BIG-IP
- 
- 
+
+
 ## Example Usage
 ```hcl
 
@@ -32,7 +32,7 @@ output "bigip_node" {
   value = "${data.bigip_ltm_node.test.fqdn[0].address_family}"
 }
 
-```      
+```
 
 ## Argument Reference
 
@@ -44,12 +44,14 @@ output "bigip_node" {
 
 Additionally, the following attributes are exported:
 * `address` - The address of the node.
-  
+
 * `description` - User defined description of the node.
 
 * `connection_limit` - Node connection limit.
 
 * `dynamic_ratio` - The dynamic ratio number for the node.
+
+* `full_path` - Full path of the node (partition and name)
 
 * `monitor` - Specifies the health monitors the system currently uses to monitor this node.
 


### PR DESCRIPTION
Add `full_path` to the `bigip_ltm_node data source`. The reason for this addition is that `name` and `id` do not include the Partition as most other data sources do. I added `full_path` because I was worried about breaking people who are already using the `bigip_ltm_node` data source. The alternative would have been to fix this `id` and `name` properties at the risk of breaking consumers of the provider.

This PR also updates datasource_bigip_ltm_node_test.go to verify that the data source is pulling the FullPath from the resource.