### PR TITLE
fixes #553

### DIFF
--- a/bigip/resource_bigip_ltm_monitor.go
+++ b/bigip/resource_bigip_ltm_monitor.go
@@ -22,7 +22,7 @@ var parentMonitors = map[string]bool{
 	"/Common/http":          true,
 	"/Common/https":         true,
 	"/Common/icmp":          true,
-	"/Common/gateway-icmp":  true,
+	"/Common/gateway_icmp":  true,
 	"/Common/tcp":           true,
 	"/Common/tcp-half-open": true,
 	"/Common/ftp":           true,
@@ -53,7 +53,7 @@ func resourceBigipLtmMonitor() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validateParent,
 				ForceNew:     true,
-				Description:  "Existing monitor to inherit from. Must be one of /Common/http, /Common/https, /Common/icmp or /Common/gateway-icmp.",
+				Description:  "Existing monitor to inherit from. Must be one of /Common/http, /Common/https, /Common/icmp or /Common/gateway_icmp.",
 			},
 			"interval": {
 				Type:        schema.TypeInt,
@@ -191,14 +191,19 @@ func resourceBigipLtmMonitor() *schema.Resource {
 func resourceBigipLtmMonitorCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*bigip.BigIP)
 	name := d.Get("name").(string)
+	parent := monitorParent(d.Get("parent").(string))
 
-	log.Println("[INFO] Creating LTM Monitor " + name + " :: " + monitorParent(d.Get("parent").(string)))
+	log.Println("[INFO] Creating LTM Monitor " + name + " :: " + parent)
 	pss := &bigip.Monitor{
 		Name: name,
 	}
 	config := getLtmMonitorConfig(d, pss)
 
-	err := client.CreateMonitor(config)
+	if strings.Contains(parent, "gateway") {
+		parent = "gateway-icmp"
+	}
+
+	err := client.CreateMonitor(config, parent)
 
 	if err != nil {
 		log.Printf("[ERROR] Unable to Create Monitor (%s) (%v) ", name, err)
@@ -305,7 +310,13 @@ func resourceBigipLtmMonitorUpdate(d *schema.ResourceData, meta interface{}) err
 	}
 	config := getLtmMonitorConfig(d, pss)
 
-	err := client.ModifyMonitor(name, monitorParent(d.Get("parent").(string)), config)
+	parent := monitorParent(d.Get("parent").(string))
+
+	if strings.Contains(parent, "gateway") {
+		parent = "gateway-icmp"
+	}
+
+	err := client.ModifyMonitor(name, parent, config)
 	if err != nil {
 		log.Printf("[ERROR] Unable to Update Monitor (%s) (%v) ", name, err)
 		return err
@@ -319,6 +330,11 @@ func resourceBigipLtmMonitorDelete(d *schema.ResourceData, meta interface{}) err
 	name := d.Id()
 	parent := monitorParent(d.Get("parent").(string))
 	log.Println("[INFO] Deleting monitor " + name + "::" + parent)
+
+	if strings.Contains(parent, "gateway") {
+		parent = "gateway-icmp"
+	}
+
 	err := client.DeleteMonitor(name, parent)
 	if err != nil {
 		log.Printf("[ERROR] Unable to Delete Monitor (%s) (%v) ", name, err)
@@ -334,7 +350,7 @@ func validateParent(v interface{}, k string) ([]string, []error) {
 		return nil, nil
 	}
 
-	return nil, []error{fmt.Errorf("parent must be one of /Common/udp, /Common/postgresql, /Common/http, /Common/https, /Common/icmp, /Common/gateway-icmp, /Common/tcp-half-open, /Common/tcp, /Common/ftp")}
+	return nil, []error{fmt.Errorf("parent must be one of /Common/udp, /Common/postgresql, /Common/http, /Common/https, /Common/icmp, /Common/gateway_icmp, /Common/tcp-half-open, /Common/tcp, /Common/ftp")}
 }
 
 func monitorParent(s string) string {
@@ -342,7 +358,7 @@ func monitorParent(s string) string {
 }
 
 func getLtmMonitorConfig(d *schema.ResourceData, config *bigip.Monitor) *bigip.Monitor {
-	config.ParentMonitor = monitorParent(d.Get("parent").(string))
+	config.ParentMonitor = d.Get("parent").(string)
 	config.Adaptive = d.Get("adaptive").(string)
 	config.AdaptiveLimit = d.Get("adaptive_limit").(int)
 	config.Compatibility = d.Get("compatibility").(string)
@@ -363,6 +379,5 @@ func getLtmMonitorConfig(d *schema.ResourceData, config *bigip.Monitor) *bigip.M
 	config.Username = d.Get("username").(string)
 	config.Password = d.Get("password").(string)
 	config.UpInterval = d.Get("up_interval").(int)
-	// config.Description
 	return config
 }

--- a/bigip/resource_bigip_ltm_monitor_test.go
+++ b/bigip/resource_bigip_ltm_monitor_test.go
@@ -22,6 +22,7 @@ var TestHttpsMonitorName = fmt.Sprintf("/%s/test-https-monitor", TEST_PARTITION)
 var TestFtpMonitorName = fmt.Sprintf("/%s/test-ftp-monitor", TEST_PARTITION)
 var TestUdpMonitorName = fmt.Sprintf("/%s/test-udp-monitor", TEST_PARTITION)
 var TestPostgresqlMonitorName = fmt.Sprintf("/%s/test-postgresql-monitor", TEST_PARTITION)
+var TestGatewayIcmpMonitorName = fmt.Sprintf("/%s/test-gateway", TEST_PARTITION)
 
 var TestMonitorResource = `
 resource "bigip_ltm_monitor" "test-monitor" {
@@ -93,6 +94,38 @@ resource "bigip_ltm_monitor" "test-postgresql-monitor" {
         database          = "postgres"
 }
 `
+
+var TestGatewayIcmpMonitorResource = `
+resource "bigip_ltm_monitor" "test-gateway-icmp-monitor" {
+  name        = "` + TestGatewayIcmpMonitorName + `"
+  parent      = "/Common/gateway_icmp"
+  timeout     = "16"
+  interval    = "5"
+  destination = "10.10.10.10:*"
+}
+`
+
+func TestAccBigipLtmMonitor_GatewayIcmpCreate(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testMonitorsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: TestGatewayIcmpMonitorResource,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckMonitorExists(TestGatewayIcmpMonitorName),
+					resource.TestCheckResourceAttr("bigip_ltm_monitor.test-gateway-icmp-monitor", "parent", "/Common/gateway_icmp"),
+					resource.TestCheckResourceAttr("bigip_ltm_monitor.test-gateway-icmp-monitor", "timeout", "16"),
+					resource.TestCheckResourceAttr("bigip_ltm_monitor.test-gateway-icmp-monitor", "interval", "5"),
+					resource.TestCheckResourceAttr("bigip_ltm_monitor.test-gateway-icmp-monitor", "destination", "10.10.10.10:*"),
+				),
+			},
+		},
+	})
+}
 
 func TestAccBigipLtmMonitor_HttpCreate(t *testing.T) {
 	t.Parallel()

--- a/vendor/github.com/f5devcentral/go-bigip/ltm.go
+++ b/vendor/github.com/f5devcentral/go-bigip/ltm.go
@@ -1013,42 +1013,40 @@ type Monitors struct {
 
 // Monitor contains information about each individual monitor.
 type Monitor struct {
-	Name      string
-	Partition string
-	//DefaultsFrom   string
-	FullPath       string
-	Generation     int
-	ParentMonitor  string
-	Description    string
-	Destination    string
-	Interval       int
-	IPDSCP         int
-	ManualResume   string
-	Password       string
-	ReceiveString  string
-	ReceiveDisable string
-	Reverse        string
-	SendString     string
-	TimeUntilUp    int
-	Timeout        int
-	Transparent    string
-	UpInterval     int
-	Username       string
-	Compatibility  string
-	Filename       string
-	Mode           string
-	Adaptive       string
-	AdaptiveLimit  int
-	Database       string
-	Count          string
-	RecvRow        string
-	RecvColumn     string
+	Name      string `json:"name,omitempty"`
+	Partition string `json:"partition,omitempty"`
+	FullPath       string `json:"fullPath,omitempty"`
+	Generation     int    `json:"generation,omitempty"`
+	ParentMonitor  string `json:"defaultsFrom,omitempty"`
+	Description    string `json:"description,omitempty"`
+	Destination    string `json:"destination,omitempty"`
+	Database       string `json:"database,omitempty"`
+	Interval       int    `json:"interval,omitempty"`
+	IPDSCP         int    `json:"ipDscp,omitempty"`
+	ManualResume   string `json:"manualResume,omitempty"`
+	Password       string `json:"password,omitempty"`
+	ReceiveString  string `json:"recv,omitempty"`
+	ReceiveDisable string `json:"recvDisable,omitempty"`
+	Reverse        string `json:"reverse,omitempty"`
+	SendString     string `json:"send,omitempty"`
+	TimeUntilUp    int    `json:"timeUntilUp,omitempty"`
+	Timeout        int    `json:"timeout,omitempty"`
+	Transparent    string `json:"transparent,omitempty"`
+	UpInterval     int    `json:"upInterval,omitempty"`
+	Username       string `json:"username,omitempty"`
+	Compatibility  string `json:"compatibility,omitempty"`
+	Filename       string `json:"filename,omitempty"`
+	Mode           string `json:"mode,omitempty"`
+	Adaptive       string `json:"adaptive,omitempty"`
+	AdaptiveLimit  int    `json:"adaptiveLimit,omitempty"`
+	Count          string `json:"count,omitempty"`
+	RecvRow        string `json:"recvRow,omitempty"`
+	RecvColumn     string `json:"recvColumn,omitempty"`
 }
 
 type monitorDTO struct {
 	Name      string `json:"name,omitempty"`
 	Partition string `json:"partition,omitempty"`
-	//DefaultsFrom   string `json:"defaultsFrom,omitempty"`
 	FullPath       string `json:"fullPath,omitempty"`
 	Generation     int    `json:"generation,omitempty"`
 	ParentMonitor  string `json:"defaultsFrom,omitempty"`
@@ -2541,11 +2539,10 @@ func (b *BigIP) Monitors() ([]Monitor, error) {
 //func (b *BigIP) CreateMonitor(config *Monitor) error
 //This Function expects Monitor struct type as input,posts the config on to BIGIP to configure LTM Monitor Objects
 //Returns Nil If Post is Success,err in case Failure
-func (b *BigIP) CreateMonitor(config *Monitor) error {
+func (b *BigIP) CreateMonitor(config *Monitor, parent string) error {
 	//config := &Monitor{
 	//	Name:           name,
 	//	ParentMonitor:  parent,
-	//	DefaultsFrom:   defaults_from,
 	//	Interval:       interval,
 	//	Timeout:        timeout,
 	//	SendString:     send,
@@ -2554,21 +2551,12 @@ func (b *BigIP) CreateMonitor(config *Monitor) error {
 	//	Compatibility:  compatibility,
 	//	Destination:    destination,
 	//}
-	return b.AddMonitor(config)
+	return b.AddMonitor(config, parent)
 }
 
 // Create a monitor by supplying a config
-func (b *BigIP) AddMonitor(config *Monitor) error {
-	if strings.Contains(config.ParentMonitor, "gateway") {
-		config.ParentMonitor = "gatewayIcmp"
-	}
-	if strings.Contains(config.ParentMonitor, "tcp-half-open") {
-		config.ParentMonitor = "tcp-half-open"
-	}
-	if strings.Contains(config.ParentMonitor, "ftp") {
-		config.ParentMonitor = "ftp"
-	}
-	return b.post(config, uriLtm, uriMonitor, config.ParentMonitor)
+func (b *BigIP) AddMonitor(config *Monitor, parent string) error {
+	return b.post(config, uriLtm, uriMonitor, parent)
 }
 
 // GetVirtualServer retrieves a monitor by name. Returns nil if the monitor does not exist
@@ -2595,16 +2583,6 @@ func (b *BigIP) DeleteMonitor(name, parent string) error {
 // one of "http", "https", "icmp", "gateway icmp", or "tcp". Fields that
 // can be modified are referenced in the Monitor struct.
 func (b *BigIP) ModifyMonitor(name, parent string, config *Monitor) error {
-	if strings.Contains(config.ParentMonitor, "gateway") {
-		config.ParentMonitor = "gatewayIcmp"
-	}
-	if strings.Contains(config.ParentMonitor, "tcp-half-open") {
-		config.ParentMonitor = "tcp-half-open"
-	}
-	if strings.Contains(config.ParentMonitor, "ftp") {
-		config.ParentMonitor = "ftp"
-	}
-
 	return b.put(config, uriLtm, uriMonitor, parent, name)
 }
 


### PR DESCRIPTION
fixes #553 

corrected default parent for gateway icmp monitor
changed Monitor struct to correctly marshall and unmarshall json blobs obtained from device
corrected URI links for ltm monitor calls