### PR TITLE
Remove sensitive flag from SSL certificate

### DIFF
--- a/bigip/resource_bigip_ssl_certificate.go
+++ b/bigip/resource_bigip_ssl_certificate.go
@@ -34,7 +34,6 @@ func resourceBigipSslCertificate() *schema.Resource {
 			"content": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Sensitive:   true,
 				ForceNew:    true,
 				Description: "Content of certificate on Disk",
 			},


### PR DESCRIPTION
An SSL certificate is generally considered not a secret since it's transmitted as part of setting up an HTTPS connection. Marking the value here as sensitive creates issues in certain workflows.

Note: reverts a small part of #209