### PR TITLE
Added port_lockdown to resource_bigip_net_selfip

### DIFF
--- a/docs/resources/bigip_net_selfip.md
+++ b/docs/resources/bigip_net_selfip.md
@@ -21,6 +21,7 @@ resource "bigip_net_selfip" "selfip1" {
   ip            = "11.1.1.1/24"
   vlan          = "/Common/internal"
   traffic_group = "traffic-group-1"
+  port_lockdown = [tcp:4040, udp:5050, egp:0]
   depends_on    = [bigip_net_vlan.vlan1]
 }
 ```      
@@ -34,3 +35,5 @@ resource "bigip_net_selfip" "selfip1" {
 * `vlan` - (Required) Specifies the VLAN for which you are setting a self IP address. This setting must be provided when a self IP is created.
 
 * `traffic_group` - (Optional) Specifies the traffic group, defaults to `traffic-group-local-only` if not specified.
+
+* `port_lockdown` - (Optional) Specifies the port lockdown, defaults to `Allow Default` if not specified.

--- a/docs/resources/bigip_net_selfip.md
+++ b/docs/resources/bigip_net_selfip.md
@@ -21,7 +21,7 @@ resource "bigip_net_selfip" "selfip1" {
   ip            = "11.1.1.1/24"
   vlan          = "/Common/internal"
   traffic_group = "traffic-group-1"
-  port_lockdown = [tcp:4040, udp:5050, egp:0]
+  port_lockdown = ["tcp:4040", "udp:5050", "egp:0"]
   depends_on    = [bigip_net_vlan.vlan1]
 }
 ```      

--- a/vendor/github.com/f5devcentral/go-bigip/net.go
+++ b/vendor/github.com/f5devcentral/go-bigip/net.go
@@ -57,17 +57,17 @@ type SelfIPs struct {
 // SelfIP contains information about each individual self IP. You can use all of
 // these fields when modifying a self IP.
 type SelfIP struct {
-	Name                  string `json:"name,omitempty"`
-	Partition             string `json:"partition,omitempty"`
-	FullPath              string `json:"fullPath,omitempty"`
-	Generation            int    `json:"generation,omitempty"`
-	Address               string `json:"address,omitempty"`
-	Floating              string `json:"floating,omitempty"`
-	InheritedTrafficGroup string `json:"inheritedTrafficGroup,omitempty"`
-	TrafficGroup          string `json:"trafficGroup,omitempty"`
-	Unit                  int    `json:"unit,omitempty"`
-	Vlan                  string `json:"vlan,omitempty"`
-	// AllowService          []string `json:"allowService"`
+	Name                  string      `json:"name,omitempty"`
+	Partition             string      `json:"partition,omitempty"`
+	FullPath              string      `json:"fullPath,omitempty"`
+	Generation            int         `json:"generation,omitempty"`
+	Address               string      `json:"address,omitempty"`
+	Floating              string      `json:"floating,omitempty"`
+	InheritedTrafficGroup string      `json:"inheritedTrafficGroup,omitempty"`
+	TrafficGroup          string      `json:"trafficGroup,omitempty"`
+	Unit                  int         `json:"unit,omitempty"`
+	Vlan                  string      `json:"vlan,omitempty"`
+	AllowService          interface{} `json:"allowService"`
 }
 
 // Trunks contains a list of every trunk on the BIG-IP system.
@@ -403,13 +403,7 @@ func (b *BigIP) SelfIP(selfip string) (*SelfIP, error) {
 
 // CreateSelfIP adds a new self IP to the BIG-IP system. For <address>, you
 // must include the subnet mask in CIDR notation, i.e.: "10.1.1.1/24".
-func (b *BigIP) CreateSelfIP(name, address, vlan string) error {
-	config := &SelfIP{
-		Name:    name,
-		Address: address,
-		Vlan:    vlan,
-	}
-
+func (b *BigIP) CreateSelfIP(config *SelfIP) error {
 	return b.post(config, uriNet, uriSelf)
 }
 


### PR DESCRIPTION
Added port_lockdown to resource bigip_net_selfip. Fixes #561 .

```
➜  terraform-provider-bigip git:(master)$ go test -v ./bigip -run="TestAccBigipNetselfip*"
=== RUN   TestAccBigipNetselfip_create
--- PASS: TestAccBigipNetselfip_create (4.28s)
=== RUN   TestAccBigipNetselfip_import
--- PASS: TestAccBigipNetselfip_import (8.16s)
=== RUN   TestAccBigipNetselfipPortlockdown
--- PASS: TestAccBigipNetselfipPortlockdown (16.54s)
PASS  
ok  	github.com/F5Networks/terraform-provider-bigip/bigip	29.318s
```