### PR TITLE
Added option to explicitly set port_lockdown to none

### DIFF
--- a/docs/resources/bigip_net_selfip.md
+++ b/docs/resources/bigip_net_selfip.md
@@ -42,7 +42,20 @@ resource "bigip_net_selfip" "selfip1" {
   port_lockdown = ["tcp:4040", "udp:5050", "egp:0"]
   depends_on    = [bigip_net_vlan.vlan1]
 }
-```      
+```
+
+### Example usage with `port_lockdown` set to `["none"]`
+
+```hcl
+resource "bigip_net_selfip" "selfip1" {
+  name          = "/Common/internalselfIP"
+  ip            = "11.1.1.1/24"
+  vlan          = "/Common/internal"
+  traffic_group = "traffic-group-1"
+  port_lockdown = ["none"]
+  depends_on    = [bigip_net_vlan.vlan1]
+}
+```
 
 ## Argument Reference
 


### PR DESCRIPTION
Related to #594 . A user can now explicitly set the value for port_lockdown as `['none']` for a SelfIP.

```
go test -v ./bigip -run="TestAccBigipNetselfip*"
=== RUN   TestAccBigipNetselfip_create
--- PASS: TestAccBigipNetselfip_create (8.52s)
=== RUN   TestAccBigipNetselfip_import
--- PASS: TestAccBigipNetselfip_import (15.52s)
=== RUN   TestAccBigipNetselfipPortlockdown
--- PASS: TestAccBigipNetselfipPortlockdown (38.53s)
PASS
ok  	github.com/F5Networks/terraform-provider-bigip/bigip	62.919s
```