### PR TITLE
ssl_profile option for https monitors

### DIFF
--- a/bigip/resource_bigip_ltm_monitor.go
+++ b/bigip/resource_bigip_ltm_monitor.go
@@ -186,6 +186,12 @@ func resourceBigipLtmMonitor() *schema.Resource {
 				Optional:    true,
 				Description: "the database in which your user is created",
 			},
+
+			"ssl_profile": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "the ssl profile",
+			},
 		},
 	}
 }
@@ -258,6 +264,7 @@ func resourceBigipLtmMonitorRead(d *schema.ResourceData, meta interface{}) error
 			_ = d.Set("destination", m.Destination)
 			if matchresult {
 				_ = d.Set("compatibility", m.Compatibility)
+				_ = d.Set("ssl_profile", m.SSLProfile)
 			} else {
 				_ = d.Set("compatibility", d.Get("compatibility").(string))
 			}
@@ -381,5 +388,6 @@ func getLtmMonitorConfig(d *schema.ResourceData, config *bigip.Monitor) *bigip.M
 	config.Username = d.Get("username").(string)
 	config.Password = d.Get("password").(string)
 	config.UpInterval = d.Get("up_interval").(int)
+	config.SSLProfile = d.Get("ssl_profile").(string)
 	return config
 }

--- a/bigip/resource_bigip_ltm_monitor_test.go
+++ b/bigip/resource_bigip_ltm_monitor_test.go
@@ -53,6 +53,7 @@ resource "bigip_ltm_monitor" "test-https-monitor" {
 	reverse = "disabled"
 	destination       = "*:8008"
 	compatibility    = "enabled"
+	ssl_profile      = "/Common/serverssl"
 }
 `
 
@@ -202,6 +203,7 @@ func TestAccBigipLtmMonitor_HttpsCreate(t *testing.T) {
 					resource.TestCheckResourceAttr("bigip_ltm_monitor.test-https-monitor", "destination", "*:8008"),
 					resource.TestCheckResourceAttr("bigip_ltm_monitor.test-https-monitor", "compatibility", "enabled"),
 					resource.TestCheckResourceAttr("bigip_ltm_monitor.test-https-monitor", "reverse", "disabled"),
+					resource.TestCheckResourceAttr("bigip_ltm_monitor.test-https-monitor", "ssl_profile", "/Common/serverssl"),
 				),
 			},
 		},

--- a/docs/resources/bigip_ltm_monitor.md
+++ b/docs/resources/bigip_ltm_monitor.md
@@ -26,6 +26,15 @@ resource "bigip_ltm_monitor" "monitor" {
   destination = "1.2.3.4:1234"
 }
 
+resource "bigip_ltm_monitor" "test-https-monitor" {
+  name        = "/Common/terraform_monitor"
+  parent      = "/Common/http"
+  ssl_profile = "/Common/serverssl"
+  send        = "GET /some/path\r\n"
+  timeout     = "999"
+  interval    = "999"
+}
+
 resource "bigip_ltm_monitor" "test-ftp-monitor" {
   name          = "/Common/ftp-test"
   parent        = "/Common/ftp"
@@ -93,3 +102,5 @@ resource "bigip_ltm_monitor" "test-postgresql-monitor" {
 * `filename` - (Optional,type `string`) Specifies the full path and file name of the file that the system attempts to download. The health check is successful if the system can download the file.
 
 * `mode` - (Optional,type `string`) Specifies the data transfer process (DTP) mode. The default value is passive. The options are passive (Specifies that the monitor sends a data transfer request to the FTP server. When the FTP server receives the request, the FTP server then initiates and establishes the data connection.) and active (Specifies that the monitor initiates and establishes the data connection with the FTP server.).
+
+* `ssl_profile` - (Optional,type `string`) Specifies the ssl profile for the monitor. It only makes sense when the parent is `/Common/https`

--- a/vendor/github.com/f5devcentral/go-bigip/ltm.go
+++ b/vendor/github.com/f5devcentral/go-bigip/ltm.go
@@ -1050,6 +1050,7 @@ type Monitor struct {
 	Count          string `json:"count,omitempty"`
 	RecvRow        string `json:"recvRow,omitempty"`
 	RecvColumn     string `json:"recvColumn,omitempty"`
+	SSLProfile     string `json:"sslProfile,omitempty"`
 }
 
 type monitorDTO struct {
@@ -1082,6 +1083,7 @@ type monitorDTO struct {
 	Count          string `json:"count,omitempty"`
 	RecvRow        string `json:"recvRow,omitempty"`
 	RecvColumn     string `json:"recvColumn,omitempty"`
+	SSLProfile     string `json:"sslProfile,omitempty"`
 }
 
 type Profiles struct {


### PR DESCRIPTION
Added ssl_profile option for https monitors. Fixes #597 

```
go test -v ./bigip -run="TestAccBigipLtmMonitor*"
=== RUN   TestAccBigipLtmMonitor_GatewayIcmpCreate
--- PASS: TestAccBigipLtmMonitor_GatewayIcmpCreate (18.44s)
=== RUN   TestAccBigipLtmMonitor_HttpCreate
=== PAUSE TestAccBigipLtmMonitor_HttpCreate
=== RUN   TestAccBigipLtmMonitor_create
--- PASS: TestAccBigipLtmMonitor_create (21.86s)
=== RUN   TestAccBigipLtmMonitor_HttpsCreate
--- PASS: TestAccBigipLtmMonitor_HttpsCreate (23.54s)
=== RUN   TestAccBigipLtmMonitor_FtpCreate
--- PASS: TestAccBigipLtmMonitor_FtpCreate (20.03s)
=== RUN   TestAccBigipLtmMonitor_UdpCreate
--- PASS: TestAccBigipLtmMonitor_UdpCreate (20.72s)
=== RUN   TestAccBigipLtmMonitor_PostgresqlCreate
--- PASS: TestAccBigipLtmMonitor_PostgresqlCreate (19.53s)
=== RUN   TestAccBigipLtmMonitor_import
--- PASS: TestAccBigipLtmMonitor_import (17.91s)
=== CONT  TestAccBigipLtmMonitor_HttpCreate
--- PASS: TestAccBigipLtmMonitor_HttpCreate (18.34s)
PASS
ok  	github.com/F5Networks/terraform-provider-bigip/bigip	160.923s
```