### PR TITLE
bigip_net_selfip - store IP in state without removing route-domain

### DIFF
--- a/docs/resources/bigip_net_selfip.md
+++ b/docs/resources/bigip_net_selfip.md
@@ -57,11 +57,24 @@ resource "bigip_net_selfip" "selfip1" {
 }
 ```
 
+### Example usage with route domain embedded in the `ip`
+
+```hcl
+resource "bigip_net_selfip" "selfip1" {
+  name          = "/Common/internalselfIP"
+  ip            = "11.1.1.1%4/24"
+  vlan          = "/Common/internal"
+  traffic_group = "traffic-group-1"
+  port_lockdown = ["none"]
+  depends_on    = [bigip_net_vlan.vlan1]
+}
+```
+
 ## Argument Reference
 
 * `name` - (Required) Name of the selfip
 
-* `ip` - (Required) The Self IP's address and netmask.
+* `ip` - (Required) The Self IP's address and netmask. The IP address could also contain the route domain, e.g. `10.12.13.14%4/24`.
 
 * `vlan` - (Required) Specifies the VLAN for which you are setting a self IP address. This setting must be provided when a self IP is created.
 


### PR DESCRIPTION
Fixes #608 

```
go test -v ./bigip -run="TestAccBigipNetselfip*"
=== RUN   TestAccBigipNetselfip_create
--- PASS: TestAccBigipNetselfip_create (10.48s)
=== RUN   TestAccBigipNetselfip_import
--- PASS: TestAccBigipNetselfip_import (27.76s)
=== RUN   TestAccBigipNetselfipPortlockdown
--- PASS: TestAccBigipNetselfipPortlockdown (41.57s)
=== RUN   TestAccBigipNetselfipRouteDomain
--- PASS: TestAccBigipNetselfipRouteDomain (22.17s)
PASS
ok  	github.com/F5Networks/terraform-provider-bigip/bigip	102.328s
```