### PR TITLE
Added import docs for persistence profiles

### DIFF
--- a/bigip/datasource_bigip_waf_signatures.go
+++ b/bigip/datasource_bigip_waf_signatures.go
@@ -95,7 +95,7 @@ func dataSourceBigipWafSignatureRead(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 	if p.Level == "none" {
-		return fmt.Errorf("[ERROR] ASM Module is not rovisioned, it is set to : (%s) ", p.Level)
+		return fmt.Errorf("[ERROR] ASM Module is not provisioned, it is set to : (%s) ", p.Level)
 	}
 
 	signatures, err := client.GetWafSignature(sid)

--- a/bigip/resource_bigip_awaf_policy.go
+++ b/bigip/resource_bigip_awaf_policy.go
@@ -245,7 +245,7 @@ func resourceBigipAwafPolicyCreate(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 	if p.Level == "none" {
-		return fmt.Errorf("[ERROR] ASM Module is not rovisioned, it is set to : (%s) ", p.Level)
+		return fmt.Errorf("[ERROR] ASM Module is not provisioned, it is set to : (%s) ", p.Level)
 	}
 
 	config, err := getpolicyConfig(d)

--- a/bigip/resource_bigip_ltm_persistence_profile_cookie.go
+++ b/bigip/resource_bigip_ltm_persistence_profile_cookie.go
@@ -207,68 +207,40 @@ func resourceBigipLtmPersistenceProfileCookieRead(d *schema.ResourceData, meta i
 		return nil
 	}
 	_ = d.Set("name", name)
-	if _, ok := d.GetOk("partition"); ok {
+	_ = d.Set("defaults_from", pp.DefaultsFrom)
+	_ = d.Set("match_across_pools", pp.MatchAcrossPools)
+	_ = d.Set("match_across_services", pp.MatchAcrossServices)
+	_ = d.Set("match_across_virtuals", pp.MatchAcrossVirtuals)
+	_ = d.Set("mirror", pp.Mirror)
+	_ = d.Set("override_conn_limit", pp.OverrideConnectionLimit)
+	_ = d.Set("httponly", pp.HTTPOnly)
+	_ = d.Set("expiration", pp.Expiration)
+	_ = d.Set("always_send", pp.AlwaysSend)
+	_ = d.Set("hash_length", pp.HashLength)
+	_ = d.Set("hash_offset", pp.HashOffset)
+	_ = d.Set("method", pp.Method)
+	if timeout, err := strconv.Atoi(pp.Timeout); err == nil {
+		d.Set("timeout", timeout)
+	}
+
+	if _, ok := d.GetOk("app_service"); ok {
 		if err := d.Set("app_service", pp.AppService); err != nil {
 			return fmt.Errorf("[DEBUG] Error saving AppService to state for PersistenceProfileCookie (%s): %s", d.Id(), err)
 		}
 	}
-	if _, ok := d.GetOk("partition"); ok {
-		if err := d.Set("defaults_from", pp.DefaultsFrom); err != nil {
-			return fmt.Errorf("[DEBUG] Error saving DefaultsFrom to state for PersistenceProfileCookie (%s): %s", d.Id(), err)
-		}
-	}
-	if _, ok := d.GetOk("partition"); ok {
-		_ = d.Set("match_across_pools", pp.MatchAcrossPools)
-	}
-	if _, ok := d.GetOk("partition"); ok {
-		_ = d.Set("match_across_services", pp.MatchAcrossServices)
-	}
-	if _, ok := d.GetOk("partition"); ok {
-		_ = d.Set("match_across_virtuals", pp.MatchAcrossVirtuals)
-	}
-	if _, ok := d.GetOk("partition"); ok {
-		if err := d.Set("mirror", pp.Mirror); err != nil {
-			return fmt.Errorf("[DEBUG] Error saving Mirror to state for PersistenceProfileCookie (%s): %s", d.Id(), err)
-		}
-	}
-	if _, ok := d.GetOk("partition"); ok {
-		_ = d.Set("method", pp.Method)
-	}
-	if _, ok := d.GetOk("partition"); ok {
-		_ = d.Set("timeout", pp.Timeout)
-	}
-	if _, ok := d.GetOk("partition"); ok {
-		_ = d.Set("override_conn_limit", pp.OverrideConnectionLimit)
-	}
 	// Specific to CookiePersistenceProfile
-	if _, ok := d.GetOk("partition"); ok {
-
-		_ = d.Set("always_send", pp.AlwaysSend)
-	}
-	if _, ok := d.GetOk("partition"); ok {
+	if _, ok := d.GetOk("cookie_encryption"); ok {
 		if err := d.Set("cookie_encryption", pp.CookieEncryption); err != nil {
 			return fmt.Errorf("[DEBUG] Error saving CookieEncryption to state for PersistenceProfileCookie (%s): %s", d.Id(), err)
 		}
 	}
-	if _, ok := d.GetOk("partition"); ok {
+	if _, ok := d.GetOk("cookie_encryption_passphrase"); ok {
 		if err := d.Set("cookie_encryption_passphrase", pp.CookieEncryptionPassphrase); err != nil {
 			return fmt.Errorf("[DEBUG] Error saving CookieEncryptionPassphrase to state for PersistenceProfileCookie (%s): %s", d.Id(), err)
 		}
 	}
-	if _, ok := d.GetOk("partition"); ok {
+	if _, ok := d.GetOk("cookie_name"); ok {
 		_ = d.Set("cookie_name", pp.CookieName)
-	}
-	if _, ok := d.GetOk("partition"); ok {
-		_ = d.Set("expiration", pp.Expiration)
-	}
-	if _, ok := d.GetOk("partition"); ok {
-		_ = d.Set("hash_length", pp.HashLength)
-	}
-	if _, ok := d.GetOk("partition"); ok {
-		_ = d.Set("hash_offset", pp.HashOffset)
-	}
-	if _, ok := d.GetOk("partition"); ok {
-		_ = d.Set("httponly", pp.HTTPOnly)
 	}
 
 	return nil

--- a/bigip/resource_bigip_ltm_persistence_profile_dstaddr.go
+++ b/bigip/resource_bigip_ltm_persistence_profile_dstaddr.go
@@ -155,35 +155,20 @@ func resourceBigipLtmPersistenceProfileDstAddrRead(d *schema.ResourceData, meta 
 	}
 
 	_ = d.Set("name", name)
+	_ = d.Set("defaults_from", pp.DefaultsFrom)
+	_ = d.Set("match_across_pools", pp.MatchAcrossPools)
+	_ = d.Set("match_across_services", pp.MatchAcrossServices)
+	_ = d.Set("match_across_virtuals", pp.MatchAcrossVirtuals)
+	_ = d.Set("mirror", pp.Mirror)
+	_ = d.Set("override_conn_limit", pp.OverrideConnectionLimit)
+	if timeout, err := strconv.Atoi(pp.Timeout); err == nil {
+		d.Set("timeout", timeout)
+	}
+
 	if _, ok := d.GetOk("app_service"); ok {
 		if err := d.Set("app_service", pp.AppService); err != nil {
 			return fmt.Errorf("[DEBUG] Error saving AppService to state for resourceBigipLtmPersistenceProfileDstAddr (%s): %s", d.Id(), err)
 		}
-	}
-	if _, ok := d.GetOk("defaults_from"); ok {
-		if err := d.Set("defaults_from", pp.DefaultsFrom); err != nil {
-			return fmt.Errorf("[DEBUG] Error saving DefaultsFrom to state for resourceBigipLtmPersistenceProfileDstAddr (%s): %s", d.Id(), err)
-		}
-	}
-	if _, ok := d.GetOk("match_across_pools"); ok {
-		d.Set("match_across_pools", pp.MatchAcrossPools)
-	}
-	if _, ok := d.GetOk("match_across_services"); ok {
-		d.Set("match_across_services", pp.MatchAcrossServices)
-	}
-	if _, ok := d.GetOk("match_across_virtuals"); ok {
-		d.Set("match_across_virtuals", pp.MatchAcrossVirtuals)
-	}
-	if _, ok := d.GetOk("mirror"); ok {
-		if err := d.Set("mirror", pp.Mirror); err != nil {
-			return fmt.Errorf("[DEBUG] Error saving Mirror to state for resourceBigipLtmPersistenceProfileDstAddr (%s): %s", d.Id(), err)
-		}
-	}
-	if _, ok := d.GetOk("timeout"); ok {
-		d.Set("timeout", pp.Timeout)
-	}
-	if _, ok := d.GetOk("override_conn_limit"); ok {
-		d.Set("override_conn_limit", pp.OverrideConnectionLimit)
 	}
 	// Specific to DestAddrPersistenceProfile
 	if _, ok := d.GetOk("hash_algorithm"); ok {

--- a/bigip/resource_bigip_ltm_persistence_profile_srcaddr.go
+++ b/bigip/resource_bigip_ltm_persistence_profile_srcaddr.go
@@ -163,37 +163,22 @@ func resourceBigipLtmPersistenceProfileSrcAddrRead(d *schema.ResourceData, meta 
 		return nil
 	}
 	_ = d.Set("name", name)
+	_ = d.Set("defaults_from", pp.DefaultsFrom)
+	_ = d.Set("match_across_pools", pp.MatchAcrossPools)
+	_ = d.Set("match_across_services", pp.MatchAcrossServices)
+	_ = d.Set("match_across_virtuals", pp.MatchAcrossVirtuals)
+	_ = d.Set("mirror", pp.Mirror)
+	_ = d.Set("override_conn_limit", pp.OverrideConnectionLimit)
+	if timeout, err := strconv.Atoi(pp.Timeout); err == nil {
+		d.Set("timeout", timeout)
+	}
+
 	if _, ok := d.GetOk("app_service"); ok {
 		if err := d.Set("app_service", pp.AppService); err != nil {
 			return fmt.Errorf("[DEBUG] Error saving AppService to state for PersistenceProfileSrcAddr (%s): %s", d.Id(), err)
 		}
 	}
 
-	if _, ok := d.GetOk("defaults_from"); ok {
-		if err := d.Set("defaults_from", pp.DefaultsFrom); err != nil {
-			return fmt.Errorf("[DEBUG] Error saving DefaultsFrom to state for PersistenceProfileSrcAddr (%s): %s", d.Id(), err)
-		}
-	}
-	if _, ok := d.GetOk("match_across_pools"); ok {
-		_ = d.Set("match_across_pools", pp.MatchAcrossPools)
-	}
-	if _, ok := d.GetOk("match_across_services"); ok {
-		_ = d.Set("match_across_services", pp.MatchAcrossServices)
-	}
-	if _, ok := d.GetOk("match_across_virtuals"); ok {
-		_ = d.Set("match_across_virtuals", pp.MatchAcrossVirtuals)
-	}
-	if _, ok := d.GetOk("mirror"); ok {
-		if err := d.Set("mirror", pp.Mirror); err != nil {
-			return fmt.Errorf("[DEBUG] Error saving Mirror to state for PersistenceProfileSrcAddr (%s): %s", d.Id(), err)
-		}
-	}
-	if _, ok := d.GetOk("timeout"); ok {
-		_ = d.Set("timeout", pp.Timeout)
-	}
-	if _, ok := d.GetOk("override_conn_limit"); ok {
-		_ = d.Set("override_conn_limit", pp.OverrideConnectionLimit)
-	}
 	// Specific to SourceAddrPersistenceProfile
 	if _, ok := d.GetOk("hash_algorithm"); ok {
 		if err := d.Set("hash_algorithm", pp.HashAlgorithm); err != nil {

--- a/bigip/resource_bigip_ltm_persistence_profile_ssl.go
+++ b/bigip/resource_bigip_ltm_persistence_profile_ssl.go
@@ -7,7 +7,6 @@ If a copy of the MPL was not distributed with this file,You can obtain one at ht
 package bigip
 
 import (
-	"fmt"
 	"log"
 	"strconv"
 
@@ -138,32 +137,14 @@ func resourceBigipLtmPersistenceProfileSSLRead(d *schema.ResourceData, meta inte
 		return nil
 	}
 	_ = d.Set("name", name)
-	if _, ok := d.GetOk("defaults_from"); ok {
-		d.Set("defaults_from", pp.DefaultsFrom)
-	}
-	if _, ok := d.GetOk("match_across_pools"); ok {
-		if err := d.Set("match_across_pools", pp.MatchAcrossPools); err != nil {
-			return fmt.Errorf("[DEBUG] Error saving MatchAcrossPools to state for PersistenceProfile SSL  (%s): %s", d.Id(), err)
-		}
-	}
-	if _, ok := d.GetOk("match_across_services"); ok {
-		if err := d.Set("match_across_services", pp.MatchAcrossServices); err != nil {
-			return fmt.Errorf("[DEBUG] Error saving MatchAcrossServices to state for PersistenceProfile SSL  (%s): %s", d.Id(), err)
-		}
-	}
-	if _, ok := d.GetOk("match_across_virtuals"); ok {
-		if err := d.Set("match_across_virtuals", pp.MatchAcrossVirtuals); err != nil {
-			return fmt.Errorf("[DEBUG] Error saving MatchAcrossVirtuals to state for PersistenceProfile SSL  (%s): %s", d.Id(), err)
-		}
-	}
-	if _, ok := d.GetOk("mirror"); ok {
-		d.Set("mirror", pp.Mirror)
-	}
-	if _, ok := d.GetOk("timeout"); ok {
-		d.Set("timeout", pp.Timeout)
-	}
-	if _, ok := d.GetOk("override_conn_limit"); ok {
-		d.Set("override_conn_limit", pp.OverrideConnectionLimit)
+	_ = d.Set("defaults_from", pp.DefaultsFrom)
+	_ = d.Set("match_across_pools", pp.MatchAcrossPools)
+	_ = d.Set("match_across_services", pp.MatchAcrossServices)
+	_ = d.Set("match_across_virtuals", pp.MatchAcrossVirtuals)
+	_ = d.Set("mirror", pp.Mirror)
+	_ = d.Set("override_conn_limit", pp.OverrideConnectionLimit)
+	if timeout, err := strconv.Atoi(pp.Timeout); err == nil {
+		d.Set("timeout", timeout)
 	}
 	return nil
 }

--- a/docs/resources/bigip_ltm_persistence_profile_cookie.md
+++ b/docs/resources/bigip_ltm_persistence_profile_cookie.md
@@ -71,3 +71,10 @@ If this is configured specify `ignore_changes` under the `lifecycle` block to ig
 `hash_offset` (Optional) (Integer) Number of characters to skip in the cookie for the hash
 
 `httponly` (Optional) (enabled or disabled) Sending only over http
+
+## Importing
+An cookie persistence profile can be imported into this resource by supplying the Name in `full path` as `id`.
+An example is below:
+```sh
+$ terraform import bigip_ltm_persistence_profile_cookie.test_ppcookie "/Common/terraform_cookie"
+```

--- a/docs/resources/bigip_ltm_persistence_profile_dstaddr.md
+++ b/docs/resources/bigip_ltm_persistence_profile_dstaddr.md
@@ -45,3 +45,10 @@ resource "bigip_ltm_persistence_profile_dstaddr" "dstaddr" {
 `timeout` (Optional) (enabled or disabled) Timeout for persistence of the session in seconds
 
 `override_conn_limit` (Optional) (enabled or disabled) Enable or dissable pool member connection limits are overridden for persisted clients. Per-virtual connection limits remain hard limits and are not overridden.
+
+## Importing
+An dest-addr persistence profile can be imported into this resource by supplying the Name in `full path` as `id`.
+An example is below:
+```sh
+$ terraform import bigip_ltm_persistence_profile_dstaddr.dstaddr "/Common/terraform_ppdstaddr"
+```

--- a/docs/resources/bigip_ltm_persistence_profile_srcaddr.md
+++ b/docs/resources/bigip_ltm_persistence_profile_srcaddr.md
@@ -51,3 +51,10 @@ resource "bigip_ltm_persistence_profile_srcaddr" "srcaddr" {
 `mask` (Optional) Identify a range of source IP addresses to manage together as a single source address affinity persistent connection when connecting to the pool. Must be a valid IPv4 or IPv6 mask.
 
 `map_proxies` (Optional) (enabled or disabled) Directs all to the same single pool member
+
+## Importing
+An source-addr persistence profile can be imported into this resource by supplying the Name in `full path` as `id`.
+An example is below:
+```sh
+$ terraform import bigip_ltm_persistence_profile_srcaddr.srcaddr "/Common/terraform_srcaddr"
+```

--- a/docs/resources/bigip_ltm_persistence_profile_ssl.md
+++ b/docs/resources/bigip_ltm_persistence_profile_ssl.md
@@ -42,3 +42,10 @@ resource "bigip_ltm_persistence_profile_ssl" "ppssl" {
 `timeout` (Optional) (enabled or disabled) Timeout for persistence of the session in seconds
 
 `override_conn_limit` (Optional) (enabled or disabled) Enable or dissable pool member connection limits are overridden for persisted clients. Per-virtual connection limits remain hard limits and are not overridden.
+
+## Importing
+An ssl persistence profile can be imported into this resource by supplying the Name in `full path` as `id`.
+An example is below:
+```sh
+$ terraform import bigip_ltm_persistence_profile_ssl.ppssl "/Common/terraform_ssl"
+```


### PR DESCRIPTION
```
go test -v ./bigip -run="TestAccBigipLtmPersistenceProfileCookie*"
=== RUN   TestAccBigipLtmPersistenceProfileCookieCreate
--- PASS: TestAccBigipLtmPersistenceProfileCookieCreate (4.04s)
=== RUN   TestAccBigipLtmPersistenceProfileCookieImport
--- PASS: TestAccBigipLtmPersistenceProfileCookieImport (3.94s)
PASS
ok  	github.com/F5Networks/terraform-provider-bigip/bigip	8.465s

go test -v ./bigip -run="TestAccBigipLtmPersistenceProfileDstAddr*"
=== RUN   TestAccBigipLtmPersistenceProfileDstAddrCreate
--- PASS: TestAccBigipLtmPersistenceProfileDstAddrCreate (4.39s)
=== RUN   TestAccBigipLtmPersistenceProfileDstAddrImport
--- PASS: TestAccBigipLtmPersistenceProfileDstAddrImport (4.28s)
PASS
ok  	github.com/F5Networks/terraform-provider-bigip/bigip	9.008s

go test -v ./bigip -run="TestAccBigipLtmPersistenceProfileSrcAddr*"
=== RUN   TestAccBigipLtmPersistenceProfileSrcAddrCreate
--- PASS: TestAccBigipLtmPersistenceProfileSrcAddrCreate (4.25s)
=== RUN   TestAccBigipLtmPersistenceProfileSrcAddrImport
--- PASS: TestAccBigipLtmPersistenceProfileSrcAddrImport (4.21s)
PASS
ok  	github.com/F5Networks/terraform-provider-bigip/bigip	8.797s

go test -v ./bigip -run="TestAccBigipLtmPersistenceProfileSSL*"
=== RUN   TestAccBigipLtmPersistenceProfileSSLCreate
--- PASS: TestAccBigipLtmPersistenceProfileSSLCreate (4.07s)
=== RUN   TestAccBigipLtmPersistenceProfileSSLImport
--- PASS: TestAccBigipLtmPersistenceProfileSSLImport (4.08s)
PASS
ok  	github.com/F5Networks/terraform-provider-bigip/bigip	8.503s

```
