### PR TITLE
fixed bug related to traffic_group in virtual address resource

### DIFF
--- a/bigip/resource_bigip_ltm_virtual_address.go
+++ b/bigip/resource_bigip_ltm_virtual_address.go
@@ -139,7 +139,11 @@ func resourceBigipLtmVirtualAddressRead(d *schema.ResourceData, meta interface{}
 	if err := d.Set("advertize_route", va.RouteAdvertisement); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving RouteAdvertisement to state for Virtual Address  (%s): %s", d.Id(), err)
 	}
-	if err := d.Set("traffic_group", va.TrafficGroup); err != nil {
+	traffic_group := va.TrafficGroup
+	if traffic_group == "none" {
+		traffic_group = fmt.Sprintf("/Common/%s", traffic_group)
+	}
+	if err := d.Set("traffic_group", traffic_group); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving TrafficGroup to state for Virtual Address  (%s): %s", d.Id(), err)
 	}
 

--- a/bigip/resource_bigip_ltm_virtual_address_test.go
+++ b/bigip/resource_bigip_ltm_virtual_address_test.go
@@ -21,8 +21,8 @@ var TEST_VA_NAME = fmt.Sprintf("/%s/test-va", TEST_PARTITION)
 var TEST_VA_NAME_CHANGED = fmt.Sprintf("/%s/test-va-changed", TEST_PARTITION)
 var TEST_VA_CONFIG = `
 resource "bigip_ltm_virtual_address" "test-va" {
-	name = "%s"
-
+	name          = "%s"
+	traffic_group = "/Common/none"
 }
 `
 var TEST_VA_RESOURCE = fmt.Sprintf(TEST_VA_CONFIG, TEST_VA_NAME)


### PR DESCRIPTION
Fixes #671 

```
go test ./bigip -v -run="TestAccBigipLtmVA_*"
=== RUN   TestAccBigipLtmVA_create
--- PASS: TestAccBigipLtmVA_create (7.88s)
=== RUN   TestAccBigipLtmVA_import
--- PASS: TestAccBigipLtmVA_import (4.10s)
PASS
ok      github.com/F5Networks/terraform-provider-bigip/bigip    13.091s
```