### PR TITLE
Incorrect 'bigip_ltm_monitor' parent profile name validation for tcp_half_open

### DIFF
--- a/bigip/datasource_bigip_ltm_monitor.go
+++ b/bigip/datasource_bigip_ltm_monitor.go
@@ -30,7 +30,7 @@ func dataSourceBigipLtmMonitor() *schema.Resource {
 			"defaults_from": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Existing monitor to inherit from. Must be one of /Common/http, /Common/https, /Common/icmp or /Common/gateway-icmp.",
+				Description: "Existing monitor to inherit from. Must be one of /Common/http, /Common/https, /Common/icmp, /Common/gateway-icmp or /Common/tcp-half-open.",
 			},
 			"interval": {
 				Type:     schema.TypeInt,

--- a/bigip/resource_bigip_ltm_monitor.go
+++ b/bigip/resource_bigip_ltm_monitor.go
@@ -26,7 +26,7 @@ var parentMonitors = map[string]bool{
 	"/Common/icmp":          true,
 	"/Common/gateway_icmp":  true,
 	"/Common/tcp":           true,
-	"/Common/tcp-half-open": true,
+	"/Common/tcp_half_open": true,
 	"/Common/ftp":           true,
 	"/Common/ldap":          true,
 }
@@ -55,7 +55,7 @@ func resourceBigipLtmMonitor() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validateParent,
 				ForceNew:     true,
-				Description:  "Existing monitor to inherit from. Must be one of /Common/http, /Common/https, /Common/icmp or /Common/gateway_icmp.",
+				Description:  "Existing monitor to inherit from. Must be one of /Common/http, /Common/https, /Common/icmp, /Common/gateway_icmp or /Common/tcp_half_open.",
 			},
 			"interval": {
 				Type:        schema.TypeInt,
@@ -207,6 +207,9 @@ func resourceBigipLtmMonitorCreate(d *schema.ResourceData, meta interface{}) err
 	if strings.Contains(parent, "gateway") {
 		parent = "gateway-icmp"
 	}
+	if strings.Contains(parent, "tcp_half_open") {
+		parent = "tcp-half-open"
+	}
 
 	err := client.CreateMonitor(config, parent)
 
@@ -319,6 +322,9 @@ func resourceBigipLtmMonitorUpdate(d *schema.ResourceData, meta interface{}) err
 	if strings.Contains(parent, "gateway") {
 		parent = "gateway-icmp"
 	}
+	if strings.Contains(parent, "tcp_half_open") {
+		parent = "tcp-half-open"
+	}
 
 	err := client.ModifyMonitor(name, parent, config)
 	if err != nil {
@@ -338,6 +344,9 @@ func resourceBigipLtmMonitorDelete(d *schema.ResourceData, meta interface{}) err
 	if strings.Contains(parent, "gateway") {
 		parent = "gateway-icmp"
 	}
+	if strings.Contains(parent, "tcp_half_open") {
+		parent = "tcp-half-open"
+	}
 
 	err := client.DeleteMonitor(name, parent)
 	if err != nil {
@@ -354,7 +363,7 @@ func validateParent(v interface{}, k string) ([]string, []error) {
 		return nil, nil
 	}
 
-	return nil, []error{fmt.Errorf("parent must be one of /Common/udp, /Common/postgresql, /Common/mysql,/Common/mssql, /Common/http, /Common/https, /Common/icmp, /Common/gateway_icmp, /Common/tcp-half-open, /Common/tcp, /Common/ftp")}
+	return nil, []error{fmt.Errorf("parent must be one of /Common/udp, /Common/postgresql, /Common/mysql,/Common/mssql, /Common/http, /Common/https, /Common/icmp, /Common/gateway_icmp, /Common/tcp_half_open, /Common/tcp, /Common/ftp")}
 }
 
 func monitorParent(s string) string {

--- a/bigip/resource_bigip_ltm_monitor_test.go
+++ b/bigip/resource_bigip_ltm_monitor_test.go
@@ -23,6 +23,7 @@ var TestFtpMonitorName = fmt.Sprintf("/%s/test-ftp-monitor", TEST_PARTITION)
 var TestUdpMonitorName = fmt.Sprintf("/%s/test-udp-monitor", TEST_PARTITION)
 var TestPostgresqlMonitorName = fmt.Sprintf("/%s/test-postgresql-monitor", TEST_PARTITION)
 var TestGatewayIcmpMonitorName = fmt.Sprintf("/%s/test-gateway", TEST_PARTITION)
+var TestTcpHalfOpenMonitorName = fmt.Sprintf("/%s/test-tcp-half-open", TEST_PARTITION)
 
 var TestMonitorResource = `
 resource "bigip_ltm_monitor" "test-monitor" {
@@ -106,6 +107,16 @@ resource "bigip_ltm_monitor" "test-gateway-icmp-monitor" {
 }
 `
 
+var TestTcpHalfOpenMonitorResource = `
+resource "bigip_ltm_monitor" "test-tcp-half-open-monitor" {
+  name        = "` + TestTcpHalfOpenMonitorName + `"
+  parent      = "/Common/tcp_half_open"
+  timeout     = "16"
+  interval    = "5"
+  destination = "10.10.10.10:1234"
+}
+`
+
 func TestAccBigipLtmMonitor_GatewayIcmpCreate(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -122,6 +133,28 @@ func TestAccBigipLtmMonitor_GatewayIcmpCreate(t *testing.T) {
 					resource.TestCheckResourceAttr("bigip_ltm_monitor.test-gateway-icmp-monitor", "timeout", "16"),
 					resource.TestCheckResourceAttr("bigip_ltm_monitor.test-gateway-icmp-monitor", "interval", "5"),
 					resource.TestCheckResourceAttr("bigip_ltm_monitor.test-gateway-icmp-monitor", "destination", "10.10.10.10:*"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBigipLtmMonitor_TcpHalfOpenCreate(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testMonitorsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: TestTcpHalfOpenMonitorResource,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckMonitorExists(TestTcpHalfOpenMonitorName),
+					resource.TestCheckResourceAttr("bigip_ltm_monitor.test-tcp-half-open-monitor", "parent", "/Common/tcp_half_open"),
+					resource.TestCheckResourceAttr("bigip_ltm_monitor.test-tcp-half-open-monitor", "timeout", "16"),
+					resource.TestCheckResourceAttr("bigip_ltm_monitor.test-tcp-half-open-monitor", "interval", "5"),
+					resource.TestCheckResourceAttr("bigip_ltm_monitor.test-tcp-half-open-monitor", "destination", "10.10.10.10:1234"),
 				),
 			},
 		},


### PR DESCRIPTION
Fixes #690
* Correcting URI for tcp_half_open monitor.
* Adding testcase for the change.