### PR TITLE
Changes in attribute names for FAST TCP

### DIFF
--- a/docs/resources/bigip_fast_tcp_app.md
+++ b/docs/resources/bigip_fast_tcp_app.md
@@ -25,7 +25,7 @@ resource "bigip_fast_tcp_app" "fast-tcp-app" {
     port = 443
   }
 
-  fast_create_pool_members {
+  pool_members {
     addresses        = ["10.11.34.65", "56.43.23.76"]
     port             = 443
     priority_group   = 1
@@ -47,11 +47,11 @@ See [virtual server](#virtual-server) below for more details.
 
 * `existing_snat_pool` - (Optional,`string`) Name of an existing BIG-IP SNAT pool.
 
-* `fast_create_snat_pool_address` - (Optional,`list`) List of address to be used for FAST-Generated SNAT Pool.
+* `snat_pool_address` - (Optional,`list`) List of address to be used for FAST-Generated SNAT Pool.
 
-* `exist_pool_name` - (Optional,`string`) Name of an existing BIG-IP pool.
+* `existing_pool` - (Optional,`string`) Name of an existing BIG-IP pool.
 
-* `fast_create_pool_members` - (Optional,`set`) `fast_create_pool_members` block takes input for FAST-Generated Pool.
+* `pool_members` - (Optional,`set`) `pool_members` block takes input for FAST-Generated Pool.
 See [Pool Members](#pool-members) below for more details.
 
 * `load_balancing_mode` - (Optional,`string`) A `load balancing method` is an algorithm that the BIG-IP system uses to select a pool member for processing a request. F5 recommends the Least Connections load balancing method
@@ -60,7 +60,7 @@ See [Pool Members](#pool-members) below for more details.
 
 * `existing_monitor` - (Optional,`string`) Name of an existing BIG-IP HTTPS pool monitor. Monitors are used to determine the health of the application on each server.
 
-* `fast_create_monitor` - (Optional,`set`) `fast_create_monitor` block takes input for FAST-Generated Pool Monitor.
+* `monitor` - (Optional,`set`) `monitor` block takes input for FAST-Generated Pool Monitor.
 See [Pool Monitor](#pool-monitor) below for more details.
 
 
@@ -78,7 +78,7 @@ The `virtual_server` block supports the following:
 
 Using this block will `enable` for FAST-Generated Pool.
 
-The `fast_create_pool_members` block supports the following:
+The `pool_members` block supports the following:
 
 * `addresses` - (Optional , `list`) List of server address to be used for FAST-Generated Pool.
 
@@ -95,6 +95,6 @@ The `fast_create_pool_members` block supports the following:
 
 Using this block will `enable` for FAST-Generated Pool Monitor. Unlike FAST HTTP and HTTPS apps, TCP only has the `interval` option here.
 
-The `fast_create_monitor` block supports the following:
+The `monitor` block supports the following:
 
 * `interval` - (Optional , `int`) Set the time between health checks,in seconds for FAST-Generated Pool Monitor. 


### PR DESCRIPTION
Changes in attribute names in FAST TCP, as suggested by Patrick

```
go test ./bigip -v -run="TestAccFastTCPAppCreateOnBigip"
=== RUN   TestAccFastTCPAppCreateOnBigip
--- PASS: TestAccFastTCPAppCreateOnBigip (35.20s)
PASS
ok  	github.com/F5Networks/terraform-provider-bigip/bigip	35.579s
```