### PR TITLE
Replaced PATCH with POST in modify to fix idempotency issue

### DIFF
--- a/bigip/resource_bigip_fast_tcp.go
+++ b/bigip/resource_bigip_fast_tcp.go
@@ -260,18 +260,19 @@ func resourceBigipFastTcpAppUpdate(d *schema.ResourceData, meta interface{}) err
 	m.Lock()
 	defer m.Unlock()
 
-	name := d.Get("application").(string)
-	tenant := d.Get("tenant").(string)
 	cfg, err := getParamsConfigMap(d)
 	log.Printf("[INFO] Updating FastApp Config :%v", cfg)
 	if err != nil {
-		return nil
+		return err
 	}
-	err = client.ModifyFastAppBigip(cfg, tenant, name)
+	const templateName string = "bigip-fast-templates/tcp"
+	userAgent := fmt.Sprintf("?userAgent=%s/%s", client.UserAgent, templateName)
+	_, _, err = client.PostFastAppBigip(cfg, templateName, userAgent)
 
 	if err != nil {
 		return err
 	}
+
 	return resourceBigipFastTcpAppRead(d, meta)
 }
 


### PR DESCRIPTION
This is to fix idempotency bug in FAST TCP, I have changed the call medthod from PATH to POST in the modify operation.

```
go test -v ./bigip -run="TestAccFastTCPAppCreateOnBigip"
=== RUN   TestAccFastTCPAppCreateOnBigip
--- PASS: TestAccFastTCPAppCreateOnBigip (47.05s)
PASS
ok  	github.com/F5Networks/terraform-provider-bigip/bigip	48.130s
(py39)
```