### PR TITLE
Add support for verified accept on LTM TCP profile

### DIFF
--- a/bigip/resource_bigip_ltm_profile_tcp.go
+++ b/bigip/resource_bigip_ltm_profile_tcp.go
@@ -85,6 +85,12 @@ func resourceBigipLtmProfileTcp() *schema.Resource {
 				Computed:    true,
 				Description: "If enabled (default), the system can use the TCP Fast Open protocol extension to reduce latency by sending payload data with initial SYN",
 			},
+			"verified_accept": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "If enabled, the system verifies that the pool member is available to accept the connection by sending the server a SYN before responding to the client's SYN with a SYN-ACK.",
+			},
 		},
 	}
 }
@@ -103,6 +109,7 @@ func resourceBigipLtmProfileTcpCreate(d *schema.ResourceData, meta interface{}) 
 		KeepAliveInterval: d.Get("keepalive_interval").(int),
 		DeferredAccept:    d.Get("deferred_accept").(string),
 		FastOpen:          d.Get("fast_open").(string),
+		VerifiedAccept:    d.Get("verified_accept").(string),
 	}
 	log.Println("[INFO] Creating TCP profile")
 	err := client.CreateTcp(tcpProfileConfig)
@@ -129,6 +136,7 @@ func resourceBigipLtmProfileTcpUpdate(d *schema.ResourceData, meta interface{}) 
 		KeepAliveInterval: d.Get("keepalive_interval").(int),
 		DeferredAccept:    d.Get("deferred_accept").(string),
 		FastOpen:          d.Get("fast_open").(string),
+		VerifiedAccept:    d.Get("verified_accept").(string),
 	}
 	err := client.ModifyTcp(name, tcpProfileConfig)
 	if err != nil {
@@ -186,6 +194,9 @@ func resourceBigipLtmProfileTcpRead(d *schema.ResourceData, meta interface{}) er
 	}
 	if _, ok := d.GetOk("fast_open"); ok {
 		_ = d.Set("fast_open", obj.FastOpen)
+	}
+	if _, ok := d.GetOk("verified_accept"); ok {
+		_ = d.Set("verified_accept", obj.VerifiedAccept)
 	}
 	return nil
 }

--- a/bigip/resource_bigip_ltm_profile_tcp_test.go
+++ b/bigip/resource_bigip_ltm_profile_tcp_test.go
@@ -29,6 +29,23 @@ resource "bigip_ltm_profile_tcp" "test-tcp" {
             keepalive_interval = 1700
             deferred_accept = "enabled"
             fast_open = "enabled"
+				verified_accept = "disabled"
+        }
+`
+
+var TEST_TCP_RESOURCE_VERIFIED_ACCEPT = `
+resource "bigip_ltm_profile_tcp" "test-tcp" {
+            name = "/Common/sanjose-tcp-wan-profile"
+            defaults_from = "/Common/tcp-wan-optimized"
+						partition = "Common"
+            idle_timeout = 300
+            close_wait_timeout = 5
+            finwait_2timeout = 5
+            finwait_timeout = 300
+            keepalive_interval = 1700
+            deferred_accept = "enabled"
+            fast_open = "disabled"
+            verified_accept = "enabled"
         }
 `
 
@@ -54,6 +71,36 @@ func TestAccBigipLtmProfileTcp_create(t *testing.T) {
 					resource.TestCheckResourceAttr("bigip_ltm_profile_tcp.test-tcp", "keepalive_interval", "1700"),
 					resource.TestCheckResourceAttr("bigip_ltm_profile_tcp.test-tcp", "deferred_accept", "enabled"),
 					resource.TestCheckResourceAttr("bigip_ltm_profile_tcp.test-tcp", "fast_open", "enabled"),
+					resource.TestCheckResourceAttr("bigip_ltm_profile_tcp.test-tcp", "verified_accept", "disabled"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBigipLtmProfileTcp_create_verified_accept(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckTcpsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: TEST_TCP_RESOURCE_VERIFIED_ACCEPT,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckTcpExists(TEST_TCP_NAME, true),
+					resource.TestCheckResourceAttr("bigip_ltm_profile_tcp.test-tcp", "name", "/Common/sanjose-tcp-wan-profile"),
+					resource.TestCheckResourceAttr("bigip_ltm_profile_tcp.test-tcp", "defaults_from", "/Common/tcp-wan-optimized"),
+					resource.TestCheckResourceAttr("bigip_ltm_profile_tcp.test-tcp", "idle_timeout", "300"),
+					resource.TestCheckResourceAttr("bigip_ltm_profile_tcp.test-tcp", "partition", "Common"),
+					resource.TestCheckResourceAttr("bigip_ltm_profile_tcp.test-tcp", "close_wait_timeout", "5"),
+					resource.TestCheckResourceAttr("bigip_ltm_profile_tcp.test-tcp", "finwait_2timeout", "5"),
+					resource.TestCheckResourceAttr("bigip_ltm_profile_tcp.test-tcp", "finwait_timeout", "300"),
+					resource.TestCheckResourceAttr("bigip_ltm_profile_tcp.test-tcp", "keepalive_interval", "1700"),
+					resource.TestCheckResourceAttr("bigip_ltm_profile_tcp.test-tcp", "deferred_accept", "enabled"),
+					resource.TestCheckResourceAttr("bigip_ltm_profile_tcp.test-tcp", "fast_open", "disabled"),
+					resource.TestCheckResourceAttr("bigip_ltm_profile_tcp.test-tcp", "verified_accept", "enabled"),
 				),
 			},
 		},

--- a/docs/resources/bigip_ltm_profile_tcp.md
+++ b/docs/resources/bigip_ltm_profile_tcp.md
@@ -52,3 +52,5 @@ resource "bigip_ltm_profile_tcp" "sanjose-tcp-lan-profile" {
 * `fast_open` - (Optional) When enabled, permits TCP Fast Open, allowing properly equipped TCP clients to send data with the SYN packet.
 
 * `deferred_accept` - (Optional) Specifies, when enabled, that the system defers allocation of the connection chain context until the client response is received. This option is useful for dealing with 3-way handshake DOS attacks. The default value is disabled.
+
+* `verified_accept` - (Optional) When enabled, the system verifies that the pool member is available to accept the connection by sending the server a SYN before responding to the client's SYN with a SYN-ACK.

--- a/vendor/github.com/f5devcentral/go-bigip/ltm.go
+++ b/vendor/github.com/f5devcentral/go-bigip/ltm.go
@@ -1152,6 +1152,7 @@ type tcpDTO struct {
 	KeepAliveInterval int    `json:"keepAliveInterval,omitempty"`
 	DeferredAccept    string `json:"deferredAccept,omitempty"`
 	FastOpen          string `json:"fastOpen,omitempty"`
+	VerifiedAccept    string `json:"verifiedAccept,omitempty"`
 }
 
 type Tcps struct {
@@ -1169,6 +1170,7 @@ type Tcp struct {
 	KeepAliveInterval int
 	DeferredAccept    string
 	FastOpen          string
+	VerifiedAccept    string
 }
 
 type Ftp struct {


### PR DESCRIPTION
Fixes #724

* Adding new optional parameter 'verified_accept' to the TCP profile.
* Adding testcases for the change.