### PR TITLE
Added cipher_group parameter to client and server ssl profile

### DIFF
--- a/bigip/resource_bigip_ltm_profile_ssl_client_test.go
+++ b/bigip/resource_bigip_ltm_profile_ssl_client_test.go
@@ -394,6 +394,43 @@ func TestAccBigipLtmProfileClientSsl_UpdateCipher(t *testing.T) {
 	})
 }
 
+func TestAccBigipLtmProfileClientSsl_UpdateCipherGroup(t *testing.T) {
+	t.Parallel()
+	var instName = "test-ClientSsl-UpdateCipherGroup"
+	var instFullName = fmt.Sprintf("/%s/%s", TEST_PARTITION, instName)
+	resFullName := fmt.Sprintf("%s.%s", resName, instName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckClientSslDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testaccbigipltmprofileclientsslDefaultcreate(instName),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckClientSslExists(instFullName),
+					resource.TestCheckResourceAttr(resFullName, "name", instFullName),
+					resource.TestCheckResourceAttr(resFullName, "partition", "Common"),
+					resource.TestCheckResourceAttr(resFullName, "defaults_from", "/Common/clientssl"),
+					resource.TestCheckResourceAttr(resFullName, "cipher_group", "none"),
+				),
+			},
+			{
+				Config: testaccbigipltmprofileclientsslUpdateparam(instName, "cipher_group"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckClientSslExists(instFullName),
+					resource.TestCheckResourceAttr(resFullName, "name", instFullName),
+					resource.TestCheckResourceAttr(resFullName, "partition", "Common"),
+					resource.TestCheckResourceAttr(resFullName, "defaults_from", "/Common/clientssl"),
+					resource.TestCheckResourceAttr(resFullName, "cipher_group", "/Common/f5-aes"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccBigipLtmProfileClientSsl_import(t *testing.T) {
 	var instName = "test-ClientSsl"
 	var instFullName = fmt.Sprintf("/%s/%s", TEST_PARTITION, instName)
@@ -530,6 +567,9 @@ func testaccbigipltmprofileclientsslUpdateparam(instName, updateParam string) st
 	case "ciphers":
 		resPrefix = fmt.Sprintf(`%s
 			  ciphers = "AES"`, resPrefix)
+	case "cipher_group":
+		resPrefix = fmt.Sprintf(`%s
+				cipher_group = "/Common/f5-aes"`, resPrefix)
 	default:
 	}
 	return fmt.Sprintf(`%s

--- a/bigip/resource_bigip_ltm_profile_ssl_server_test.go
+++ b/bigip/resource_bigip_ltm_profile_ssl_server_test.go
@@ -151,6 +151,42 @@ func TestAccBigipLtmProfileServerSsl_UpdateTmoptions(t *testing.T) {
 	})
 }
 
+func TestAccBigipLtmProfileServerSsl_UpdateCipherGroup(t *testing.T) {
+	t.Parallel()
+	var instName = "test-ServerSsl-UpdateCipherGroup"
+	var instFullName = fmt.Sprintf("/%s/%s", TEST_PARTITION, instName)
+	resFullName := fmt.Sprintf("%s.%s", resNameserver, instName)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckServerSslDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testaccbigipltmprofileserversslDefaultcreate(instName),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckServerSslExists(instFullName),
+					resource.TestCheckResourceAttr(resFullName, "name", instFullName),
+					resource.TestCheckResourceAttr(resFullName, "partition", "Common"),
+					resource.TestCheckResourceAttr(resFullName, "defaults_from", "/Common/serverssl"),
+					resource.TestCheckResourceAttr(resFullName, "cipher_group", "none"),
+				),
+			},
+			{
+				Config: testAccBigipLtmProfileServerSsl_UpdateParam(instName, "cipher_group"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckServerSslExists(instFullName),
+					resource.TestCheckResourceAttr(resFullName, "name", instFullName),
+					resource.TestCheckResourceAttr(resFullName, "partition", "Common"),
+					resource.TestCheckResourceAttr(resFullName, "defaults_from", "/Common/serverssl"),
+					resource.TestCheckResourceAttr(resFullName, "cipher_group", "/Common/f5-aes"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccBigipLtmProfileServerSsl_import(t *testing.T) {
 	var instName = "test-ServerSsl"
 	var instFullName = fmt.Sprintf("/%s/%s", TEST_PARTITION, instName)
@@ -229,6 +265,9 @@ func testAccBigipLtmProfileServerSsl_UpdateParam(instName, updateParam string) s
 	case "tm_options":
 		resPrefix = fmt.Sprintf(`%s
 			  tm_options = ["no-tlsv1.3"]`, resPrefix)
+	case "cipher_group":
+		resPrefix = fmt.Sprintf(`%s
+			  cipher_group = "/Common/f5-aes"`, resPrefix)
 	}
 	return fmt.Sprintf(`%s
 		}`, resPrefix)

--- a/docs/resources/bigip_ltm_profile_client_ssl.md
+++ b/docs/resources/bigip_ltm_profile_client_ssl.md
@@ -47,6 +47,8 @@ Don't insert empty fragments and No TLSv1.3 are listed as Enabled Options. `Usag
 
 * `ciphers` - (Optional) Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
 
+* `cipher_group` - (Optional) Specifies the cipher group for the SSL server profile. It is mutually exclusive with the argument, `ciphers`. The default value is `none`.
+
 * `peer_cert_mode` - (Optional) Specifies the way the system handles client certificates.When ignore, specifies that the system ignores certificates from client systems.When require, specifies that the system requires a client to present a valid certificate.When request, specifies that the system requests a valid certificate from a client but always authenticate the client.
 
 * `renegotiation` - (Optional) Enables or disables SSL renegotiation.When creating a new profile, the setting is provided by the parent profile

--- a/docs/resources/bigip_ltm_profile_server_ssl.md
+++ b/docs/resources/bigip_ltm_profile_server_ssl.md
@@ -40,6 +40,8 @@ resource "bigip_ltm_profile_server_ssl" "test-ServerSsl" {
 
 * `ciphers` - (Optional) Specifies the list of ciphers that the system supports. When creating a new profile, the default cipher list is provided by the parent profile.
 
+* `cipher_group` - (Optional) Specifies the cipher group for the SSL server profile. It is mutually exclusive with the argument, `ciphers`. The default value is `none`.
+
 * `peer_cert_mode` - (Optional) Specifies the way the system handles client certificates.When ignore, specifies that the system ignores certificates from client systems.When require, specifies that the system requires a client to present a valid certificate.When request, specifies that the system requests a valid certificate from a client but always authenticate the client.
 
 * `authenticate` - (Optional) Specifies the frequency of server authentication for an SSL session.When `once`,specifies that the system authenticates the server once for an SSL session.

--- a/vendor/github.com/f5devcentral/go-bigip/ltm.go
+++ b/vendor/github.com/f5devcentral/go-bigip/ltm.go
@@ -48,6 +48,7 @@ type ServerSSLProfile struct {
 	Cert                         string      `json:"cert,omitempty"`
 	Chain                        string      `json:"chain,omitempty"`
 	Ciphers                      string      `json:"ciphers,omitempty"`
+	CipherGroup                  string      `json:"cipherGroup,omitempty"`
 	DefaultsFrom                 string      `json:"defaultsFrom,omitempty"`
 	ExpireCertResponseControl    string      `json:"expireCertResponseControl,omitempty"`
 	GenericAlert                 string      `json:"genericAlert,omitempty"`
@@ -118,6 +119,7 @@ type ClientSSLProfile struct {
 	CertLookupByIpaddrPort          string      `json:"certLookupByIpaddrPort,omitempty"`
 	Chain                           string      `json:"chain,omitempty"`
 	Ciphers                         string      `json:"ciphers,omitempty"`
+	CipherGroup                     string      `json:"cipherGroup,omitempty"`
 	ClientCertCa                    string      `json:"clientCertCa,omitempty"`
 	CrlFile                         string      `json:"crlFile,omitempty"`
 	DefaultsFrom                    string      `json:"defaultsFrom,omitempty"`
@@ -2081,7 +2083,7 @@ func (b *BigIP) GetClientSSLProfile(name string) (*ClientSSLProfile, error) {
 	if !ok {
 		return nil, nil
 	}
-
+	log.Printf("------------------ssl profile: %+v-----------------", clientSSLProfile)
 	return &clientSSLProfile, nil
 }
 


### PR DESCRIPTION
Added new parameter cipher_group to client and server ssl profile.

```
❯ go test ./bigip -v -run=TestAccBigipLtmProfileClientSsl_UpdateCipherGroup
=== RUN   TestAccBigipLtmProfileClientSsl_UpdateCipherGroup
=== PAUSE TestAccBigipLtmProfileClientSsl_UpdateCipherGroup
=== CONT  TestAccBigipLtmProfileClientSsl_UpdateCipherGroup
--- PASS: TestAccBigipLtmProfileClientSsl_UpdateCipherGroup (8.28s)
PASS
ok  	github.com/F5Networks/terraform-provider-bigip/bigip	9.051s
```

```
❯ go test ./bigip -v -run=TestAccBigipLtmProfileServerSsl_UpdateCipherGroup
=== RUN   TestAccBigipLtmProfileServerSsl_UpdateCipherGroup
=== PAUSE TestAccBigipLtmProfileServerSsl_UpdateCipherGroup
=== CONT  TestAccBigipLtmProfileServerSsl_UpdateCipherGroup
--- PASS: TestAccBigipLtmProfileServerSsl_UpdateCipherGroup (8.43s)
PASS
ok  	github.com/F5Networks/terraform-provider-bigip/bigip	8.783s
```