### PR TITLE
Improved test coverage

### DIFF
--- a/bigip/datasource_bigip_ltm_datagroup_unit_test.go
+++ b/bigip/datasource_bigip_ltm_datagroup_unit_test.go
@@ -1,0 +1,75 @@
+package bigip
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func dataGroupCfg(address string) string {
+	return fmt.Sprintf(`
+	provider "bigip" {
+	  address   = "%s"
+	  username  = ""
+	  password  = ""
+	  login_ref = ""
+	}
+	data "bigip_ltm_datagroup" "images" {
+		name      = "images"
+		partition = "Common"
+	  }	
+	`, address)
+}
+
+func TestAccBigipDataGroupUnit(t *testing.T) {
+	setup()
+	defer teardown()
+	mux.HandleFunc("/mgmt/tm/ltm/data-group/internal/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `
+		{
+			"name": "images",
+			"partition": "Common",
+			"type": "string",
+			"records": [
+				{
+					"name": ".bmp",
+					"data": ""
+				},
+				{
+					"name": ".gif",
+					"data": ""
+				}
+			]
+		}
+		`)
+	})
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dataGroupCfg(server.URL),
+			},
+		},
+	})
+}
+
+func TestAccBigipDataGroupUnit_nil(t *testing.T) {
+	setup()
+	defer teardown()
+	mux.HandleFunc("/mgmt/tm/ltm/data-group/internal/", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"code": 404}`, 404)
+		// w.WriteHeader(http.StatusNotFound)
+	})
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dataGroupCfg(server.URL),
+			},
+		},
+	})
+}

--- a/bigip/datasource_bigip_ltm_irule_unit_test.go
+++ b/bigip/datasource_bigip_ltm_irule_unit_test.go
@@ -1,0 +1,65 @@
+package bigip
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func dataIruleCfg(address string) string {
+	return fmt.Sprintf(`
+	provider "bigip" {
+	  address   = "%s"
+	  username  = ""
+	  password  = ""
+	  login_ref = ""
+	}
+	data "bigip_ltm_irule" "terraform_irule" {
+	  name      = "terraform_irule"
+	  partition = "Common"
+	}	
+	`, address)
+}
+
+func TestAccBigipIruleUnit(t *testing.T) {
+	setup()
+	defer teardown()
+	mux.HandleFunc("/mgmt/tm/ltm/rule/~Common~terraform_irule", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `
+		{
+			"name": "terraform_irule",
+			"partition": "Common",
+			"apiAnonymous": "test irule",
+			"fullPath": "/Common/terraform_irule"
+		}
+		`)
+	})
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dataIruleCfg(server.URL),
+			},
+		},
+	})
+}
+
+func TestAccBigipIruleUnit_nil(t *testing.T) {
+	setup()
+	defer teardown()
+	mux.HandleFunc("/mgmt/tm/ltm/rule/~Common~terraform_irule", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"code": 404}`, 404)
+	})
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dataIruleCfg(server.URL),
+			},
+		},
+	})
+}

--- a/bigip/datasource_bigip_ltm_monitor_unit_test.go
+++ b/bigip/datasource_bigip_ltm_monitor_unit_test.go
@@ -1,0 +1,80 @@
+package bigip
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func dataMonitorCfg(address string) string {
+	return fmt.Sprintf(`
+	provider "bigip" {
+	  address   = "%s"
+	  username  = ""
+	  password  = ""
+	  login_ref = ""
+	}
+	data "bigip_ltm_monitor" "test-monitor" {
+	  name      = "test-monitor"
+	  partition = "Common"
+	}	
+	`, address)
+}
+
+func TestAccBigipMonitorUnit(t *testing.T) {
+	monitors := []string{"http", "https", "icmp", "gateway-icmp", "tcp", "tcp-half-open", "ftp", "udp", "postgresql", "mysql", "mssql", "ldap"}
+	setup()
+	defer teardown()
+
+	for _, name := range monitors {
+		mux.HandleFunc(fmt.Sprintf("/mgmt/tm/ltm/monitor/%s", name), func(w http.ResponseWriter, r *http.Request) {
+			req_url := r.URL.String()
+			if strings.HasSuffix(req_url, "http") {
+				fmt.Fprintf(w, `{
+					"items": [
+						{
+							"name": "/Common/test-monitor",
+							"partition": "Common",
+							"fullPath": "/Common/test-monitor",
+							"defaultsFrom": "/Common/http"
+						}
+					]
+				}`)
+			} else {
+				fmt.Fprintf(w, `{"items":[]}`)
+			}
+		})
+	}
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dataMonitorCfg(server.URL),
+			},
+		},
+	})
+}
+
+func TestAccBigipMonitorUnit_nil(t *testing.T) {
+	monitors := []string{"http", "https", "icmp", "gateway-icmp", "tcp", "tcp-half-open", "ftp", "udp", "postgresql", "mysql", "mssql", "ldap"}
+	setup()
+	defer teardown()
+	for _, name := range monitors {
+		mux.HandleFunc(fmt.Sprintf("/mgmt/tm/ltm/monitor/%s", name), func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, `{"items": []}`)
+		})
+	}
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dataMonitorCfg(server.URL),
+			},
+		},
+	})
+}

--- a/bigip/datasource_bigip_ltm_node_unit_test.go
+++ b/bigip/datasource_bigip_ltm_node_unit_test.go
@@ -1,0 +1,96 @@
+package bigip
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func dataNodeCfg(address string) string {
+	return fmt.Sprintf(`
+	provider "bigip" {
+	  address   = "%s"
+	  username  = ""
+	  password  = ""
+	  login_ref = ""
+	}
+	data "bigip_ltm_node" "terraform_node" {
+	  name      = "terraform_node"
+	  partition = "Common"
+	}	
+	`, address)
+}
+
+func TestAccBigipNodeUnit(t *testing.T) {
+	setup()
+	defer teardown()
+	mux.HandleFunc("/mgmt/tm/ltm/node/~Common~terraform_node", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `
+		{
+			"name": "terraform_node",
+			"partition": "Common",
+			"fullPath": "/Common/terraform_node",
+			"address": "1.2.3.4"
+		}
+		`)
+	})
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dataNodeCfg(server.URL),
+			},
+		},
+	})
+}
+
+func TestAccBigipNodeUnit_fqdn(t *testing.T) {
+	setup()
+	defer teardown()
+	mux.HandleFunc("/mgmt/tm/ltm/node/~Common~terraform_node", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `
+		{
+			"name": "terraform_node",
+			"partition": "Common",
+			"fullPath": "/Common/terraform_node",
+			"address": "any6",
+			"fqdn": {
+				"tmName": "www.fqdn.com"
+			}
+		}
+		`)
+	})
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dataNodeCfg(server.URL),
+			},
+		},
+	})
+}
+
+func TestAccBigipNodeUnit_nil(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/mgmt/tm/ltm/node/~Common~terraform_node", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"code": 404}`, 404)
+	})
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dataNodeCfg(server.URL),
+			},
+		},
+	})
+}

--- a/bigip/datasource_bigip_ltm_policy_unity_test.go
+++ b/bigip/datasource_bigip_ltm_policy_unity_test.go
@@ -1,0 +1,109 @@
+package bigip
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/stretchr/testify/assert"
+)
+
+func dataPolicyCfg(address string) string {
+	return fmt.Sprintf(`
+	provider "bigip" {
+	  address   = "%s"
+	  username  = ""
+	  password  = ""
+	  login_ref = ""
+	}
+	data "bigip_ltm_policy" "test_policy" {
+	  name = "/Common/test_policy"
+	}	
+	`, address)
+}
+
+func TestAccBigipPolicyUnit(t *testing.T) {
+	setup()
+	defer teardown()
+	mux.HandleFunc("/mgmt/tm/ltm/policy/Common~test_policy", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "Expected GET, got %s", r.Method)
+		fmt.Fprintf(w, `
+		{
+			"name": "test_policy",
+			"partition": "partition",
+			"fullPath": "/Common/test_policy",
+			"strategy": "/Common/best-match",
+			"controls": ["caching"]
+		}
+		`)
+	})
+	mux.HandleFunc("/mgmt/tm/ltm/policy/Common~test_policy/rules", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "Expected GET, got %s", r.Method)
+		fmt.Fprintf(w, `
+		{
+			"items": [
+				{
+					"name": "test_rule",
+					"fullPath": "test_rule",
+					"actionsReference": {},
+					"conditionsReference": {}
+				}
+			]
+		}
+		`)
+	})
+
+	mux.HandleFunc("/mgmt/tm/ltm/policy/Common~test_policy/rules/test_rule/actions", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "Expected GET, got %s", r.Method)
+		fmt.Fprintf(w, `
+		{
+			"items": [
+				{
+					"name": "0",
+					"fullPath": "0"
+				}
+			]
+		}
+		`)
+	})
+	mux.HandleFunc("/mgmt/tm/ltm/policy/Common~test_policy/rules/test_rule/conditions", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "Expected GET, got %s", r.Method)
+		fmt.Fprintf(w, `
+		{
+			"items": [
+				{
+					"name": "0",
+					"fullPath": "0"
+				}
+			]
+		}
+		`)
+	})
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dataPolicyCfg(server.URL),
+			},
+		},
+	})
+}
+
+func TestAccBigipPolicyUnit_nil(t *testing.T) {
+	setup()
+	defer teardown()
+	mux.HandleFunc("/mgmt/tm/ltm/policy/Common~test_policy", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"code": 404}`, 404)
+	})
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dataPolicyCfg(server.URL),
+			},
+		},
+	})
+}

--- a/bigip/datasource_bigip_ltm_pool_unit_test.go
+++ b/bigip/datasource_bigip_ltm_pool_unit_test.go
@@ -1,0 +1,48 @@
+package bigip
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func dataPoolCfg(address string) string {
+	return fmt.Sprintf(`
+	provider "bigip" {
+	  address   = "%s"
+	  username  = ""
+	  password  = ""
+	  login_ref = ""
+	}
+	data "bigip_ltm_pool" "test_pool" {
+	  name      = "test_pool"
+	  partition = "Common"
+	}	
+	`, address)
+}
+
+func TestAccBigipPoolUnit(t *testing.T) {
+	setup()
+	defer teardown()
+	mux.HandleFunc("/mgmt/tm/ltm/pool/~Common~test_pool", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `
+		{
+			"name": "test_pool",
+			"partition": "Common",
+			"fullPath": "/Common/test_pool"
+		}
+		`)
+	})
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dataPoolCfg(server.URL),
+			},
+		},
+	})
+}

--- a/bigip/datasource_bigip_ssl_certificate_unit_test.go
+++ b/bigip/datasource_bigip_ssl_certificate_unit_test.go
@@ -1,0 +1,48 @@
+package bigip
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func dataSSLCertificateCfg(address string) string {
+	return fmt.Sprintf(`
+	provider "bigip" {
+	  address   = "%s"
+	  username  = ""
+	  password  = ""
+	  login_ref = ""
+	}
+	data "bigip_ssl_certificate" "test" {
+	  name      = "terraform_ssl_certificate"
+	  partition = "Common"
+	}	
+	`, address)
+}
+
+func TestAccBigipSSLCertificateUnit(t *testing.T) {
+	setup()
+	defer teardown()
+	mux.HandleFunc("/mgmt/tm/sys/file/ssl-cert/~Common~terraform_ssl_certificate", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `
+		{
+			"name": "terraform_ssl_certificate",
+			"partition": "Common",
+			"fullPath": "/Common/terraform_ssl_certificate"
+		}
+		`)
+	})
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dataSSLCertificateCfg(server.URL),
+			},
+		},
+	})
+}

--- a/bigip/datasource_bigip_waf_entity_parameters_unit_test.go
+++ b/bigip/datasource_bigip_waf_entity_parameters_unit_test.go
@@ -1,0 +1,72 @@
+package bigip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func dataWAFEntityParametersCfg(address string) string {
+	return fmt.Sprintf(`
+	provider "bigip" {
+	  address   = "%s"
+	  username  = ""
+	  password  = ""
+	  login_ref = ""
+	}
+	data "bigip_waf_entity_parameter" "test_ep" {
+	  name = "test_entity_param"
+	  type = "explicit"
+	  value_type = "user-input"
+	  allow_empty_type = true
+	  allow_repeated_parameter_name = true
+	  attack_signatures_check = true
+	  check_max_value_length = false
+	  check_min_value_length = false
+	  data_type = "alpha_numeric"
+	  enable_regular_expression = false
+	  is_base64 = false
+	  is_cookie = false
+	  is_header = false
+	  level = "url"
+	  mandatory = false
+	  metachars_on_parameter_value_check = false
+	  parameter_location = "any"
+	  perform_staging = true
+	  sensitive_parameter = false
+	  signature_overrides_disable = [200002290, 200002292]
+	  url {
+		name = "test.com"
+		method = "GET"
+		protocol = "HTTP"
+		type = "explicit"
+	  }
+	}	
+	`, address)
+}
+
+func TestAccBigipWAFEntityParametersUnit(t *testing.T) {
+	setup()
+	defer teardown()
+
+	js := `{"name":"test_entity_param","type":"explicit","valueType":"user-input","allowRepeatedParameterName":true,"attackSignaturesCheck":true,"dataType":"alpha_numeric","level":"url","parameterLocation":"any","performStaging":true,"signatureOverrides":[{"enabled":false,"signatureId":200002290},{"enabled":false,"signatureId":200002292}],"url":{"method":"GET","name":"test.com","protocol":"HTTP","type":"explicit"}}`
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dataWAFEntityParametersCfg(server.URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.bigip_waf_entity_parameter.test_ep", "value_type", "user-input"),
+					resource.TestCheckResourceAttr("data.bigip_waf_entity_parameter.test_ep", "url.0.method", "GET"),
+					resource.TestCheckResourceAttr("data.bigip_waf_entity_parameter.test_ep", "url.0.name", "test.com"),
+					resource.TestCheckResourceAttr("data.bigip_waf_entity_parameter.test_ep", "url.0.protocol", "HTTP"),
+					resource.TestCheckResourceAttr("data.bigip_waf_entity_parameter.test_ep", "url.0.type", "explicit"),
+					resource.TestCheckResourceAttr("data.bigip_waf_entity_parameter.test_ep", "json", js),
+				),
+			},
+		},
+	})
+}

--- a/bigip/datasource_bigip_waf_entity_url_unit_test.go
+++ b/bigip/datasource_bigip_waf_entity_url_unit_test.go
@@ -1,0 +1,54 @@
+package bigip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func dataWAFEntityURLCfg(address string) string {
+	return fmt.Sprintf(`
+	provider "bigip" {
+	  address   = "%s"
+	  username  = ""
+	  password  = ""
+	  login_ref = ""
+	}
+	data "bigip_waf_entity_url" "test_entity_url" {
+	  name                        = "test_entity_url"
+	  type                        = "explicit"
+	  protocol                    = "HTTP"
+	  perform_staging             = true
+	  signature_overrides_disable = [200002029, 200002092]
+	  method_overrides {
+		allow  = false
+		method = "HTTPS"
+	  }
+	}	
+	`, address)
+}
+
+func TestAccBigipWAFEntityURLUnit(t *testing.T) {
+	setup()
+	defer teardown()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dataWAFEntityURLCfg(server.URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.bigip_waf_entity_url.test_entity_url", "type", "explicit"),
+					resource.TestCheckResourceAttr("data.bigip_waf_entity_url.test_entity_url", "method_overrides.0.allow", "false"),
+					resource.TestCheckResourceAttr("data.bigip_waf_entity_url.test_entity_url", "method_overrides.0.method", "HTTPS"),
+					resource.TestCheckResourceAttr("data.bigip_waf_entity_url.test_entity_url", "perform_staging", "true"),
+					resource.TestCheckResourceAttr("data.bigip_waf_entity_url.test_entity_url", "signature_overrides_disable.0", "200002029"),
+					resource.TestCheckResourceAttr("data.bigip_waf_entity_url.test_entity_url", "signature_overrides_disable.1", "200002092"),
+					resource.TestCheckNoResourceAttr("data.bigip_waf_entity_url.test_entity_url", "signature_overrides_disable.2"),
+				),
+			},
+		},
+	})
+}

--- a/bigip/datasource_bigip_waf_pb_suggestions_unit_test.go
+++ b/bigip/datasource_bigip_waf_pb_suggestions_unit_test.go
@@ -1,0 +1,98 @@
+package bigip
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/stretchr/testify/assert"
+)
+
+func dataWAFPbSuggestionsCfg(address string) string {
+	return fmt.Sprintf(`
+	provider "bigip" {
+	  address   = "%s"
+	  username  = ""
+	  password  = ""
+	  login_ref = ""
+	}
+	data "bigip_waf_pb_suggestions" "pb_suggestions" {
+	  policy_name            = "test_policy"
+	  partition              = "Common"
+	  minimum_learning_score = 7
+	}	
+	`, address)
+}
+
+func TestAccBigipWAFPbSuggestionsUnit(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/mgmt/tm/asm/policies/", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "Expected method GET, got %s", r.Method)
+
+		fmt.Fprintf(w, `
+		{
+			"items": [
+				{
+					"name": "test_policy",
+					"partition": "Common",
+					"id": "xyz"
+				}
+			]
+		}
+		`)
+	})
+
+	mux.HandleFunc("/mgmt/tm/asm/tasks/export-suggestions", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method, "Expected method POST, got %s", r.Method)
+
+		fmt.Fprintf(w, `
+		{
+			"status": "COMPLETED",
+			"id": "1",
+			"result": {}
+		}
+		`)
+	})
+
+	counter := 0
+	mux.HandleFunc("/mgmt/tm/asm/tasks/export-suggestions/1", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "Expected method GET, got %s", r.Method)
+
+		if counter < 2 {
+			fmt.Fprintf(w, `
+		{
+			"status": "IN PROGRESS",
+			"id": "1",
+			"result": {}
+		}
+		`)
+			counter += 1
+		} else {
+			fmt.Fprintf(w, `
+		{
+			"status": "COMPLETED",
+			"id": "1",
+			"result": {}
+		}
+		`)
+		}
+	})
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dataWAFPbSuggestionsCfg(server.URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.bigip_waf_pb_suggestions.pb_suggestions", "policy_name", "test_policy"),
+					resource.TestCheckResourceAttr("data.bigip_waf_pb_suggestions.pb_suggestions", "partition", "Common"),
+					resource.TestCheckResourceAttr("data.bigip_waf_pb_suggestions.pb_suggestions", "minimum_learning_score", "7"),
+				),
+			},
+		},
+	})
+}

--- a/bigip/datasource_bigip_waf_policy_unit_test.go
+++ b/bigip/datasource_bigip_waf_policy_unit_test.go
@@ -1,0 +1,81 @@
+package bigip
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/stretchr/testify/assert"
+)
+
+func dataWAFPolicyCfg(address string) string {
+	return fmt.Sprintf(`
+	provider "bigip" {
+	  address   = "%s"
+	  username  = ""
+	  password  = ""
+	  login_ref = ""
+	}
+	data "bigip_waf_policy" "test_policy" {
+	  policy_id = "test_policy_id"
+	}	
+	`, address)
+}
+
+func TestAccBigipWAFPolicyUnit(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/mgmt/tm/asm/policies/test_policy_id", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "Expected method GET, got %s", r.Method)
+
+		fmt.Fprintf(w, `
+		{
+			"items": [
+				{
+					"name": "test_policy",
+					"partition": "Common",
+					"id": "test_policy_id"
+				}
+			]
+		}
+		`)
+	})
+
+	mux.HandleFunc("/mgmt/tm/asm/tasks/export-policy", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method, "Expected method POST, got %s", r.Method)
+
+		fmt.Fprintf(w, `
+		{
+			"status": "COMPLETED",
+			"id": "1",
+			"result": {}
+		}
+		`)
+	})
+
+	mux.HandleFunc("/mgmt/tm/asm/tasks/export-policy/1", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "Expected method GET, got %s", r.Method)
+
+		fmt.Fprintf(w, `
+		{
+			"status": "COMPLETED",
+			"id": "1",
+			"result": {
+				"file": "{\"policy\":{\"name\": \"test_policy\",\"partition\": \"Common\",\"id\": \"test_policy_id\"}}"
+			}
+		}
+		`)
+	})
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dataWAFPolicyCfg(server.URL),
+			},
+		},
+	})
+}

--- a/bigip/datasource_bigip_waf_signatures_unit_test.go
+++ b/bigip/datasource_bigip_waf_signatures_unit_test.go
@@ -1,0 +1,73 @@
+package bigip
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/stretchr/testify/assert"
+)
+
+func dataWAFSignaturesCfg(address string) string {
+	return fmt.Sprintf(`
+	provider "bigip" {
+	  address   = "%s"
+	  username  = ""
+	  password  = ""
+	  login_ref = ""
+	}
+	data "bigip_waf_signatures" "test_signature" {
+	  signature_id = 200104004
+	}	
+	`, address)
+}
+
+func TestAccBigipWAFSignaturesUnit(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/mgmt/tm/sys/provision/asm", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "Expected 'GET', got '%s'", r.Method)
+
+		fmt.Fprintf(w, `
+		{
+			"name": "asm",
+			"fullPath": "asm",
+			"level": "nominal"
+		}
+		`)
+	})
+
+	mux.HandleFunc("/mgmt/tm/asm/signatures/", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "Expected 'GET', got '%s'", r.Method)
+
+		fmt.Fprintf(w, `
+		{
+			"items": [
+				{
+					"name": "test_sign",
+					"id": "test_sign_id",
+					"signatureId": 123456,
+					"signatureType": "request",
+					"accuracy": "low",
+					"risk": "low"
+				}
+			]
+		}
+		`)
+	})
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dataWAFSignaturesCfg(server.URL),
+				// Check: resource.ComposeTestCheckFunc(
+				// 	resource.TestCheckResourceAttr("data.bigip_waf_policy.test_policy", "policy_id", "test_policy_id"),
+				// ),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Improved unit test coverage for the following datasources:

bigip/datasource_bigip_ltm_datagroup.go
bigip/datasource_bigip_ltm_irule.go
bigip/datasource_bigip_ltm_monitor.go
bigip/datasource_bigip_ltm_node.go
bigip/datasource_bigip_ltm_policy.go
bigip/datasource_bigip_ltm_pool.go
bigip/datasource_bigip_ssl_certificate.go
bigip/datasource_bigip_waf_entity_parameters.go
bigip/datasource_bigip_waf_entity_url.go
bigip/datasource_bigip_waf_pb_suggestions.go
bigip/datasource_bigip_waf_policy.go
bigip/datasource_bigip_waf_signatures.go
bigip/datasource_bigip_ltm_datagroup_test.go
bigip/datasource_bigip_ltm_node_test.go