### PR TITLE
Updated policy_import_json behaviour for awaf

### DIFF
--- a/bigip/resource_bigip_awaf_policy.go
+++ b/bigip/resource_bigip_awaf_policy.go
@@ -526,14 +526,30 @@ func getpolicyConfig(d *schema.ResourceData) (string, error) {
 			polJsn.Policy.FullPath = fmt.Sprintf("/%s/%s", policyWaf.Partition, policyWaf.Name)
 			polJsn.Policy.Name = policyWaf.Name
 		}
+		if len(policyWaf.Description) > 0 {
+			polJsn.Policy.Description = policyWaf.Description
+		}
 		if polJsn.Policy.Template != policyWaf.Template {
 			polJsn.Policy.Template = policyWaf.Template
 		}
-		polJsn.Policy.Urls = append(polJsn.Policy.Urls, policyWaf.Urls...)
-		if policyWaf.Parameters != nil && len(policyWaf.Parameters) > 0 {
-			polJsn.Policy.Parameters = append(polJsn.Policy.Parameters, policyWaf.Parameters...)
+		if len(policyWaf.Urls) > 0 {
+			polJsn.Policy.Urls = policyWaf.Urls
 		}
-		polJsn.Policy.GraphqlProfiles = append(polJsn.Policy.GraphqlProfiles, policyWaf.GraphqlProfiles...)
+		if len(policyWaf.Parameters) > 0 {
+			polJsn.Policy.Parameters = policyWaf.Parameters
+		}
+		if len(policyWaf.Filetypes) > 0 {
+			polJsn.Policy.Filetypes = policyWaf.Filetypes
+		}
+		if len(policyWaf.GraphqlProfiles) > 0 {
+			polJsn.Policy.GraphqlProfiles = policyWaf.GraphqlProfiles
+		}
+		if len(policyWaf.OpenAPIFiles) > 0 {
+			polJsn.Policy.OpenAPIFiles = policyWaf.OpenAPIFiles
+		}
+		if len(policyWaf.ServerTechnologies) > 0 {
+			polJsn.Policy.ServerTechnologies = policyWaf.ServerTechnologies
+		}
 		policyJson.Policy = polJsn.Policy
 	}
 


### PR DESCRIPTION
Previously only URLs, parameters and GraphQL profiles provided as arguments to the bigip Terraform provider would be merged (not overwritten) with policy_import_json.

This behaviour has been changed so that arguments explicitly set in Terraform will now overwrite values in policy_import_json and number of arguments considered has been expanded to include: description, file types, OpenAPI files and server technologies.

This will allow a baseline WAF policy to fetched in Terraform and be passed in policy_import_json of the bigip_waf_policy resource which resolves #747 and allows Terraform to have better visibility of the changes that are to be applied.