### PR TITLE
add smtp to parentMonitors

### DIFF
--- a/bigip/resource_bigip_ltm_monitor.go
+++ b/bigip/resource_bigip_ltm_monitor.go
@@ -29,6 +29,7 @@ var parentMonitors = map[string]bool{
 	"/Common/tcp_half_open": true,
 	"/Common/ftp":           true,
 	"/Common/ldap":          true,
+	"/Common/smtp":          true,
 }
 
 func resourceBigipLtmMonitor() *schema.Resource {
@@ -55,7 +56,7 @@ func resourceBigipLtmMonitor() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validateParent,
 				ForceNew:     true,
-				Description:  "Existing monitor to inherit from. Must be one of /Common/http, /Common/https, /Common/icmp, /Common/gateway_icmp or /Common/tcp_half_open.",
+				Description:  "Existing monitor to inherit from. Must be one of /Common/http, /Common/https, /Common/icmp, /Common/gateway_icmp or /Common/tcp_half_open or /Common/smtp.",
 			},
 			"interval": {
 				Type:        schema.TypeInt,
@@ -363,7 +364,7 @@ func validateParent(v interface{}, k string) ([]string, []error) {
 		return nil, nil
 	}
 
-	return nil, []error{fmt.Errorf("parent must be one of /Common/udp, /Common/postgresql, /Common/mysql,/Common/mssql, /Common/http, /Common/https, /Common/icmp, /Common/gateway_icmp, /Common/tcp_half_open, /Common/tcp, /Common/ftp")}
+	return nil, []error{fmt.Errorf("parent must be one of /Common/udp, /Common/postgresql, /Common/mysql,/Common/mssql, /Common/http, /Common/https, /Common/icmp, /Common/gateway_icmp, /Common/tcp_half_open, /Common/tcp, /Common/ftp. /Common/smtp")}
 }
 
 func monitorParent(s string) string {

--- a/vendor/github.com/f5devcentral/go-bigip/ltm.go
+++ b/vendor/github.com/f5devcentral/go-bigip/ltm.go
@@ -2622,7 +2622,7 @@ func (b *BigIP) DeleteVirtualAddress(vaddr string) error {
 // Monitors returns a list of all HTTP, HTTPS, Gateway ICMP, ICMP, and TCP monitors.
 func (b *BigIP) Monitors() ([]Monitor, error) {
 	var monitors []Monitor
-	monitorUris := []string{"http", "https", "icmp", "gateway-icmp", "tcp", "tcp-half-open", "ftp", "udp", "postgresql", "mysql", "mssql", "ldap"}
+	monitorUris := []string{"http", "https", "icmp", "gateway-icmp", "tcp", "tcp-half-open", "ftp", "udp", "postgresql", "mysql", "mssql", "ldap", "smtp"}
 
 	for _, name := range monitorUris {
 		var m Monitors


### PR DESCRIPTION
hello F5
I added smtp monitor to the list of supported LTM monitors by the actual version
could you please accept this pull request.
I note that ,also,  the the API Client github.com/f5devcentral/go-bigip need a modification, I will send also a Pull request
please let me know if you have a question
thank you 