### PR TITLE
Fixed ltm datagroup import issue

### DIFF
--- a/bigip/resource_bigip_ltm_datagroup.go
+++ b/bigip/resource_bigip_ltm_datagroup.go
@@ -127,12 +127,12 @@ func resourceBigipLtmDataGroupRead(ctx context.Context, d *schema.ResourceData, 
 
 	name := d.Id()
 	log.Printf("[DEBUG] Retrieving Data Group List %s", name)
-	if d.Get("internal").(bool) {
-		datagroup, err := client.GetInternalDataGroup(name)
-		if err != nil {
-			return diag.FromErr(fmt.Errorf("Error retrieving Data Group List %s: %v ", name, err))
-		}
+	datagroup, err := client.GetInternalDataGroup(name)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("Error retrieving Data Group List %s: %v ", name, err))
+	}
 
+	if datagroup != nil {
 		if datagroup == nil {
 			log.Printf("[DEBUG] Data Group List %s not found, removing from state", name)
 			d.SetId("")

--- a/bigip/resource_bigip_ltm_datagroup.go
+++ b/bigip/resource_bigip_ltm_datagroup.go
@@ -133,11 +133,6 @@ func resourceBigipLtmDataGroupRead(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if datagroup != nil {
-		if datagroup == nil {
-			log.Printf("[DEBUG] Data Group List %s not found, removing from state", name)
-			d.SetId("")
-			return nil
-		}
 		_ = d.Set("name", datagroup.FullPath)
 		_ = d.Set("type", datagroup.Type)
 		for _, record := range datagroup.Records {


### PR DESCRIPTION
Fixes #730 

```
❯ go test -v ./bigip -run="TestAccBigipLtmDataGroup*"
=== RUN   TestAccBigipLtmDataGroup_basic
=== PAUSE TestAccBigipLtmDataGroup_basic
=== RUN   TestAccBigipLtmDataGroup_Create_TypeString
--- PASS: TestAccBigipLtmDataGroup_Create_TypeString (3.32s)
=== RUN   TestAccBigipLtmDataGroup_Create_TypeIp
--- PASS: TestAccBigipLtmDataGroup_Create_TypeIp (3.77s)
=== RUN   TestAccBigipLtmDataGroup_Create_TypeInteger
--- PASS: TestAccBigipLtmDataGroup_Create_TypeInteger (3.43s)
=== RUN   TestAccBigipLtmDataGroup_import
--- PASS: TestAccBigipLtmDataGroup_import (11.39s)
=== CONT  TestAccBigipLtmDataGroup_basic
--- PASS: TestAccBigipLtmDataGroup_basic (6.09s)
PASS
ok  	github.com/F5Networks/terraform-provider-bigip/bigip	28.571s
```