### PR TITLE
[#818] Make expiry date field y2038-compliant

### DIFF
--- a/vendor/github.com/f5devcentral/go-bigip/sys.go
+++ b/vendor/github.com/f5devcentral/go-bigip/sys.go
@@ -304,7 +304,7 @@ type Certificate struct {
 	CreatedBy               string `json:"createdBy,omitempty"`
 	CreateTime              string `json:"createTime,omitempty"`
 	Email                   string `json:"email,omitempty"`
-	ExpirationDate          int    `json:"expirationDate,omitempty"`
+	ExpirationDate          int64  `json:"expirationDate,omitempty"`
 	ExpirationString        string `json:"expirationString,omitempty"`
 	Fingerprint             string `json:"fingerprint,omitempty"`
 	FullPath                string `json:"fullPath,omitempty"`


### PR DESCRIPTION
Use an int64 to store the expiry date field in the Certificate struct. Without this patch applied, the code is not y2038-compliant and cannot deal with system certificates whose expiry date is > 2038.