### PR TITLE
Added transaction to resource_bigip_ssl_key_cert

### DIFF
--- a/bigip/resource_bigip_ssl_key_cert.go
+++ b/bigip/resource_bigip_ssl_key_cert.go
@@ -97,6 +97,10 @@ func resourceBigipSSLKeyCertCreate(ctx context.Context, d *schema.ResourceData, 
 		Passphrase: passphrase,
 	}
 
+	t, err := client.StartTransaction()
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error while starting transaction: %v", err))
+	}
 	err = client.AddKey(&keyCfg)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error while adding the ssl key: %v", err))
@@ -104,6 +108,10 @@ func resourceBigipSSLKeyCertCreate(ctx context.Context, d *schema.ResourceData, 
 	err = client.UploadCertificate(certName, certPath, partition)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error while uploading the ssl cert: %v", err))
+	}
+	err = client.CommitTransaction(t.TransID)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error while ending transaction: %d", err))
 	}
 
 	id := keyName + "_" + certName
@@ -166,6 +174,11 @@ func resourceBigipSSLKeyCertUpdate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	keyFullPath := fmt.Sprintf("/%s/%s", partition, keyName)
+
+	t, err := client.StartTransaction()
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error while trying to start transaction: %s", err))
+	}
 	err = client.ModifyKey(keyFullPath, &keyCfg)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error while trying to modify the ssl key (%s): %s", keyFullPath, err))
@@ -174,6 +187,10 @@ func resourceBigipSSLKeyCertUpdate(ctx context.Context, d *schema.ResourceData, 
 	err = client.UpdateCertificate(certName, certPath, partition)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error while updating the ssl certificate (%s): %s", certName, err))
+	}
+	err = client.CommitTransaction(t.TransID)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error while trying to end transaction: %s", err))
 	}
 
 	return resourceBigipSSLKeyCertRead(ctx, d, meta)
@@ -191,7 +208,12 @@ func resourceBigipSSLKeyCertDelete(ctx context.Context, d *schema.ResourceData, 
 	keyFullPath := "/" + partition + "/" + keyName
 	certFullPath := "/" + partition + "/" + certName
 
-	err := client.DeleteKey(keyFullPath)
+	t, err := client.StartTransaction()
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error while starting transaction: %v", err))
+	}
+
+	err = client.DeleteKey(keyFullPath)
 	if err != nil {
 		log.Printf("[ERROR] unable to delete the ssl key (%s) (%v) ", keyFullPath, err)
 	}
@@ -199,6 +221,11 @@ func resourceBigipSSLKeyCertDelete(ctx context.Context, d *schema.ResourceData, 
 	err = client.DeleteCertificate(certFullPath)
 	if err != nil {
 		log.Printf("[ERROR] unable to delete the ssl certificate (%s) (%v) ", certFullPath, err)
+	}
+
+	err = client.CommitTransaction(t.TransID)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error while ending transaction: %v", err))
 	}
 
 	d.SetId("")

--- a/bigip/resource_bigip_ssl_key_cert_test.go
+++ b/bigip/resource_bigip_ssl_key_cert_test.go
@@ -1,6 +1,9 @@
 package bigip
 
 import (
+	"fmt"
+	"log"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -13,6 +16,29 @@ resource "bigip_ssl_key_cert" "testkeycert" {
   key_content = "${file("` + folder + `/../examples/serverkey.key")}"
   cert_name    = "ssl-test-cert"
   cert_content = "${file("` + folder + `/../examples/servercert.crt")}"
+}
+`
+
+var sslProfileCertKey = `
+resource "bigip_ssl_key_cert" "testkeycert" {
+  partition   = "Common"
+  key_name    = "ssl-test-key"
+  key_content = "${file("` + folder + `/../examples/%s")}"
+  cert_name    = "ssl-test-cert"
+  cert_content = "${file("` + folder + `/../examples/%s")}"
+}
+
+resource "bigip_ltm_profile_server_ssl" "test-ServerSsl" {
+  name          = "/Common/test-ServerSsl"
+  defaults_from = "/Common/serverssl"
+  authenticate  = "always"
+  ciphers       = "DEFAULT"
+  cert          = "/Common/ssl-test-cert"
+  key           = "/Common/ssl-test-key"
+
+  depends_on = [
+	bigip_ssl_key_cert.testkeycert
+  ]
 }
 `
 
@@ -41,6 +67,47 @@ func TestAccBigipSSLCertKeyCreate(t *testing.T) {
 					resource.TestCheckResourceAttr("bigip_ssl_key_cert.testkeycert", "partition", "Common"),
 				),
 				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestAccBigipSSLCertKeyCreateCertKeyProfile(t *testing.T) {
+	create := fmt.Sprintf(sslProfileCertKey, "serverkey.key", "servercert.crt")
+	modify := fmt.Sprintf(sslProfileCertKey, "serverkey2.key", "servercert2.crt")
+	crt1Content, _ := os.ReadFile(folder + `/../examples/` + "servercert.crt")
+	key1Content, _ := os.ReadFile(folder + `/../examples/` + "serverkey.key")
+	crt2Content, _ := os.ReadFile(folder + `/../examples/` + "servercert2.crt")
+	key2Content, _ := os.ReadFile(folder + `/../examples/` + "serverkey2.key")
+
+	log.Println(create)
+	log.Println(modify)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: create,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("bigip_ssl_key_cert.testkeycert", "key_name", "ssl-test-key"),
+					resource.TestCheckResourceAttr("bigip_ssl_key_cert.testkeycert", "cert_name", "ssl-test-cert"),
+					resource.TestCheckResourceAttr("bigip_ssl_key_cert.testkeycert", "partition", "Common"),
+					resource.TestCheckResourceAttr("bigip_ssl_key_cert.testkeycert", "key_content", string(key1Content)),
+					resource.TestCheckResourceAttr("bigip_ssl_key_cert.testkeycert", "cert_content", string(crt1Content)),
+				),
+				Destroy: false,
+			},
+			{
+				Config: modify,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("bigip_ssl_key_cert.testkeycert", "key_name", "ssl-test-key"),
+					resource.TestCheckResourceAttr("bigip_ssl_key_cert.testkeycert", "cert_name", "ssl-test-cert"),
+					resource.TestCheckResourceAttr("bigip_ssl_key_cert.testkeycert", "partition", "Common"),
+					resource.TestCheckResourceAttr("bigip_ssl_key_cert.testkeycert", "key_content", string(key2Content)),
+					resource.TestCheckResourceAttr("bigip_ssl_key_cert.testkeycert", "cert_content", string(crt2Content)),
+				),
 			},
 		},
 	})

--- a/vendor/github.com/f5devcentral/go-bigip/sys.go
+++ b/vendor/github.com/f5devcentral/go-bigip/sys.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 
 	//"strings"
 	"time"
@@ -809,20 +810,17 @@ func (b *BigIP) StartTransaction() (*Transaction, error) {
 	return transaction, nil
 }
 
-func (b *BigIP) EndTransaction(tId int64) error {
+func (b *BigIP) CommitTransaction(tId int64) error {
+	b.Transaction = ""
 	commitTransaction := map[string]interface{}{
-		"state":        "VALIDATING",
-		"validateOnly": false,
+		"state": "VALIDATING",
 	}
-	payload, err := json.Marshal(commitTransaction)
-	if err != nil {
-		return fmt.Errorf("unable create commit transaction payload: %s", err)
-	}
-	err = b.patch(payload, uriMgmt, uriTm, uriTransaction, string(tId))
+	log.Printf("[INFO] Commiting Transaction with TransactionID: %v", tId)
+
+	err := b.patch(commitTransaction, uriMgmt, uriTm, uriTransaction, strconv.Itoa(int(tId)))
 	if err != nil {
 		return fmt.Errorf("%s", err)
 	}
-	b.Transaction = ""
 	return nil
 }
 


### PR DESCRIPTION
Added transaction to resource_bigip_ssl_key_cert to fix #832 

```
go test -v ./bigip -run="TestAccBigipSSLCertKeyCreate*"
=== RUN   TestAccBigipSSLCertKeyCreate
--- PASS: TestAccBigipSSLCertKeyCreate (13.38s)
=== RUN   TestAccBigipSSLCertKeyCreateCertKeyProfile
--- PASS: TestAccBigipSSLCertKeyCreateCertKeyProfile (17.21s)
PASS
ok  	github.com/F5Networks/terraform-provider-bigip/bigip	31.791s
```