### PR TITLE
adding pool attachment ipv6 support

### DIFF
--- a/bigip/resource_bigip_ltm_pool_attachment_test.go
+++ b/bigip/resource_bigip_ltm_pool_attachment_test.go
@@ -102,14 +102,6 @@ resource "bigip_ltm_pool" "test-pool" {
 }
 `
 var TestPoolResource5 = `
-resource "bigip_ltm_node" "test-node" {
-        name = "` + TestNodeName + `"
-        address = "10.10.100.11"
-        connection_limit = "0"
-        dynamic_ratio = "1"
-        monitor = "default"
-        rate_limit = "disabled"
-}
 resource "bigip_ltm_pool" "test-pool" {
         name = "` + TestPoolName + `"
         monitors = ["/Common/http"]
@@ -349,10 +341,10 @@ func TestAccBigipLtmPoolAttachment_StateSet(t *testing.T) {
 					testCheckPoolAttachment("/Common/test_pool_pa_tc1", "/Common/10.10.100.13:80", true),
 					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.pa_tc1", "pool", "/Common/test_pool_pa_tc1"),
 					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.pa_tc1", "state", "disabled"),
-					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.pa_tc1", "pool", "/Common/test_pool_pa_tc2"),
-					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.pa_tc1", "state", "forced_offline"),
-					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.pa_tc1", "pool", "/Common/test_pool_pa_tc3"),
-					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.pa_tc1", "state", "enabled"),
+					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.pa_tc2", "pool", "/Common/test_pool_pa_tc1"),
+					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.pa_tc2", "state", "forced_offline"),
+					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.pa_tc3", "pool", "/Common/test_pool_pa_tc1"),
+					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.pa_tc3", "state", "enabled"),
 				),
 			},
 		},
@@ -375,10 +367,10 @@ func TestAccBigipLtmPoolAttachment_ModifyState(t *testing.T) {
 					testCheckPoolAttachment("/Common/test_pool_pa_tc1", "/Common/10.10.100.13:80", true),
 					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.pa_tc1", "pool", "/Common/test_pool_pa_tc1"),
 					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.pa_tc1", "state", "forced_offline"),
-					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.pa_tc1", "pool", "/Common/test_pool_pa_tc2"),
-					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.pa_tc1", "state", "enabled"),
-					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.pa_tc1", "pool", "/Common/test_pool_pa_tc3"),
-					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.pa_tc1", "state", "disabled"),
+					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.pa_tc2", "pool", "/Common/test_pool_pa_tc1"),
+					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.pa_tc2", "state", "enabled"),
+					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.pa_tc3", "pool", "/Common/test_pool_pa_tc1"),
+					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.pa_tc3", "state", "disabled"),
 				),
 			},
 		},
@@ -399,10 +391,15 @@ func TestAccBigipLtmPoolAttachmentTestCases(t *testing.T) {
 					testCheckPoolAttachment("/Common/test_pool_pa_tc1", "/Common/test3.com:80", true),
 					testCheckPoolAttachment("/Common/test_pool_pa_tc1", "/Common/test_node_pa_tc5:80", true),
 					testCheckPoolAttachment("/TEST3/test_pool_pa_tc10", "/TEST3/2.3.2.2%50:8080", true),
+					testCheckPoolAttachment("/Common/tf-mypool", "/Common/2003::4.80", true),
+					testCheckPoolAttachment("/Common/tf-mypool", "/Common/fe80:0:0:0:0:0:0:12.80", true),
+					testCheckPoolAttachment("/Common/tf-mypool", "/Common/192.168.100.11:80", true),
 					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.pa_tc9", "pool", "/Common/test_pool_pa_tc9"),
 					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.pa_tc8", "pool", "/Common/test_pool_pa_tc1"),
 					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.pa_tc8", "node", "1.1.12.2:80"),
 					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.pa_tc6", "node", "/Common/test3.com:80"),
+					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.ipv6attach2", "node", "2003::4.80"),
+					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.ipv6attach3", "node", "fe80:0:0:0:0:0:0:12.80"),
 				),
 			},
 		},

--- a/docs/resources/bigip_ltm_pool_attachment.md
+++ b/docs/resources/bigip_ltm_pool_attachment.md
@@ -3,7 +3,7 @@ layout: "bigip"
 page_title: "BIG-IP: bigip_ltm_pool_attachment"
 subcategory: "Local Traffic Manager(LTM)"
 description: |-
-  Provides details about bigip_ltm_pool_attachment resource
+Provides details about bigip_ltm_pool_attachment resource
 ---
 
 # bigip\_ltm\_pool\_attachment
@@ -12,11 +12,18 @@ description: |-
 
 ## Example Usage
 
+There are two ways to use `bigip_ltm_pool_attachment` resource for `node` attribute
 
-There are two ways to use ltm_pool_attachment resource, where we can take node reference from ltm_node or we can specify node directly with ip:port/fqdn:port which will also create node and atach to pool.
+* It can be reference from `bigip_ltm_node` (or)
+* It can be specify directly with `ipv4:port`/`fqdn:port`/`ipv6.port` which will also create node and attach member to pool.
+
+~> For adding IPv6 node/member to pool it should be specific in `node` attribute in format like `ipv6_address.port`.
+IPv4 should be specified as `ipv4_address:port`
 
 
-### Pool attachment with node directly taking  `ip:port` / `fqdn:port`
+### Usage Pool attachment with node/member directly attaching to pool.
+
+node can be specified in format `ipv4:port` / `fqdn:port` / `ipv6.port`
 
 ```hcl
 resource "bigip_ltm_monitor" "monitor" {
@@ -34,14 +41,20 @@ resource "bigip_ltm_pool" "pool" {
   allow_nat           = "yes"
 }
 
-resource "bigip_ltm_pool_attachment" "attach_node" {
+# attaching ipv4 address with service port
+resource "bigip_ltm_pool_attachment" "ipv4_node_attach" {
   pool = bigip_ltm_pool.pool.name
   node = "1.1.1.1:80"
+}
+# attaching ipv6 address with service port
+resource "bigip_ltm_pool_attachment" "ipv6_node_attach" {
+  pool = bigip_ltm_pool.pool.name
+  node = "2003::4.80"
 }
 
 ```
 
-### Pool attachment with node referenced from `bigip_ltm_node`
+### Usage Pool attachment with node referenced from `bigip_ltm_node`
 
 ```hcl
 resource "bigip_ltm_monitor" "monitor" {

--- a/examples/bigip_ltm_pool_attachment.tf
+++ b/examples/bigip_ltm_pool_attachment.tf
@@ -115,6 +115,28 @@ resource "bigip_ltm_pool_attachment" "pa_tc11" {
   connection_limit = 11
 }
 
+resource "bigip_ltm_pool" "tf-mypool" {
+  name                = "/Common/tf-mypool"
+  monitors            = ["/Common/http"]
+  allow_nat           = "yes"
+  allow_snat          = "yes"
+  load_balancing_mode = "round-robin"
+}
+
+resource "bigip_ltm_pool_attachment" "ipv6attach2" {
+  pool = bigip_ltm_pool.tf-mypool.name
+  node = "2003::4.80"
+}
+resource "bigip_ltm_pool_attachment" "ipv6attach3" {
+  pool = bigip_ltm_pool.tf-mypool.name
+  node = "fe80:0:0:0:0:0:0:12.80"
+}
+resource "bigip_ltm_pool_attachment" "ipv4attach2" {
+  pool = bigip_ltm_pool.tf-mypool.name
+  node = "192.168.100.11:80"
+}
+
+
 //resource "bigip_ltm_pool" "pool" {
 //  name                = "/Common/Axiom_Environment_APP1_Pool"
 //  load_balancing_mode = "round-robin"


### PR DESCRIPTION

Test Results:
=== RUN   TestAccBigipLtmPoolAttachment_create
--- PASS: TestAccBigipLtmPoolAttachment_create (16.95s)
=== RUN   TestAccBigipLtmPoolAttachment_createFqdn
--- PASS: TestAccBigipLtmPoolAttachment_createFqdn (17.08s)
=== RUN   TestAccBigipLtmPoolAttachment_Issue381
=== PAUSE TestAccBigipLtmPoolAttachment_Issue381
=== RUN   TestAccBigipLtmPoolAttachment_Issue380
=== PAUSE TestAccBigipLtmPoolAttachment_Issue380
=== RUN   TestAccBigipLtmPoolAttachment_Issue92
=== PAUSE TestAccBigipLtmPoolAttachment_Issue92
=== RUN   TestAccBigipLtmPoolAttachment_Issue661
=== PAUSE TestAccBigipLtmPoolAttachment_Issue661
=== RUN   TestAccBigipLtmPoolAttachment_Modify
--- PASS: TestAccBigipLtmPoolAttachment_Modify (34.00s)
=== RUN   TestAccBigipLtmPoolAttachment_Delete

--- PASS: TestAccBigipLtmPoolAttachment_Delete (28.26s)
=== RUN   TestAccBigipLtmPoolAttachment_StateSet
--- PASS: TestAccBigipLtmPoolAttachment_StateSet (20.27s)
=== RUN   TestAccBigipLtmPoolAttachment_ModifyState
--- PASS: TestAccBigipLtmPoolAttachment_ModifyState (20.25s)
=== RUN   TestAccBigipLtmPoolAttachmentTestCases
--- PASS: TestAccBigipLtmPoolAttachmentTestCases (33.41s)
=== CONT  TestAccBigipLtmPoolAttachment_Issue381
=== CONT  TestAccBigipLtmPoolAttachment_Issue92
=== CONT  TestAccBigipLtmPoolAttachment_Issue380
=== CONT  TestAccBigipLtmPoolAttachment_Issue661
--- PASS: TestAccBigipLtmPoolAttachment_Issue92 (21.70s)
--- PASS: TestAccBigipLtmPoolAttachment_Issue380 (23.51s)
--- PASS: TestAccBigipLtmPoolAttachment_Issue661 (23.57s)
--- PASS: TestAccBigipLtmPoolAttachment_Issue381 (25.19s)
PASS
ok  	github.com/F5Networks/terraform-provider-bigip/bigip	197.435s