### PR TITLE
Added resource for OCSP and ocsp_stapling param to client_ssl_profile

### DIFF
--- a/bigip/provider.go
+++ b/bigip/provider.go
@@ -139,6 +139,7 @@ func Provider() *schema.Provider {
 			"bigip_sys_dns":                         resourceBigipSysDns(),
 			"bigip_sys_iapp":                        resourceBigipSysIapp(),
 			"bigip_sys_ntp":                         resourceBigipSysNtp(),
+			"bigip_sys_ocsp":                        resourceBigipSysOcsp(),
 			"bigip_sys_provision":                   resourceBigipSysProvision(),
 			"bigip_sys_snmp":                        resourceBigipSysSnmp(),
 			"bigip_sys_snmp_traps":                  resourceBigipSysSnmpTraps(),

--- a/bigip/resource_bigip_ltm_profile_ssl_client.go
+++ b/bigip/resource_bigip_ltm_profile_ssl_client.go
@@ -328,6 +328,13 @@ func resourceBigipLtmProfileClientSsl() *schema.Resource {
 				Description: "ModSSL Methods enabled / disabled.  Default is disabled.",
 			},
 
+			"ocsp_stapling": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "disabled",
+				Description: "Specifies whether the system uses OCSP stapling.",
+			},
+
 			"tm_options": {
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -686,6 +693,10 @@ func resourceBigipLtmProfileClientSSLRead(ctx context.Context, d *schema.Resourc
 		_ = d.Set("tm_options", tmOptions)
 	}
 
+	if _, ok := d.GetOk("ocsp_stapling"); ok {
+		_ = d.Set("ocsp_stapling", obj.OcspStapling)
+	}
+
 	if _, ok := d.GetOk("proxy_ca_cert"); ok {
 		_ = d.Set("proxy_ca_cert", obj.ProxyCaCert)
 	}
@@ -856,6 +867,7 @@ func getClientSslConfig(d *schema.ResourceData, config *bigip.ClientSSLProfile) 
 	config.CaFile = d.Get("ca_file").(string)
 	config.CacheSize = d.Get("cache_size").(int)
 	config.CacheTimeout = d.Get("cache_timeout").(int)
+	config.OcspStapling = d.Get("ocsp_stapling").(string)
 	log.Printf("[DEBUG] Length of certKeyChains :%+v", len(certKeyChains))
 	log.Printf("[DEBUG] certKeyChains :%+v", certKeyChains)
 	if len(certKeyChains) == 0 {

--- a/bigip/resource_bigip_sys_ocsp.go
+++ b/bigip/resource_bigip_sys_ocsp.go
@@ -1,0 +1,336 @@
+package bigip
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	bigip "github.com/f5devcentral/go-bigip"
+	"github.com/f5devcentral/go-bigip/f5teem"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceBigipSysOcsp() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBigipSysOcspCreate,
+		ReadContext:   resourceBigipSysOcspRead,
+		UpdateContext: resourceBigipSysOcspUpdate,
+		DeleteContext: resourceBigipSysOcspDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Description: "Specifies the name of the OCSP responder. It should be of the pattern '/partition/name'",
+				Required:    true,
+			},
+			"proxy_server_pool": {
+				Type:          schema.TypeString,
+				Description:   "Specifies the proxy server pool the BIG-IP system uses to fetch the OCSP response. It should be of the pattern '/partition/pool-name'",
+				ConflictsWith: []string{"dns_resolver"},
+				Optional:      true,
+			},
+			"dns_resolver": {
+				Type:          schema.TypeString,
+				Description:   "Specifies the internal DNS resolver the BIG-IP system uses to fetch the OCSP response. It should be of the pattern '/partition/resolver-name'",
+				ConflictsWith: []string{"proxy_server_pool"},
+				Optional:      true,
+			},
+			"route_domain": {
+				Type:        schema.TypeString,
+				Description: "Specifies the route domain for the OCSP responder",
+				Optional:    true,
+			},
+			"concurrent_connections_limit": {
+				Type:        schema.TypeInt,
+				Description: "Specifies the maximum number of connections per second allowed for the OCSP certificate validator",
+				Optional:    true,
+				Default:     50,
+			},
+			"responder_url": {
+				Type:        schema.TypeString,
+				Description: "Specifies the URL of the OCSP responder",
+				Optional:    true,
+			},
+			"connection_timeout": {
+				Type:        schema.TypeInt,
+				Description: "Specifies the time interval that the BIG-IP system waits for before ending the connection to the OCSP responder, in seconds",
+				Optional:    true,
+				Default:     8,
+			},
+			"trusted_responders": {
+				Type:        schema.TypeString,
+				Description: "Specifies the certificates used for validating the OCSP response",
+				Optional:    true,
+			},
+			"clock_skew": {
+				Type:        schema.TypeInt,
+				Description: "Specifies the tolerable absolute difference in the clocks of the responder and the BIG-IP system, in seconds",
+				Optional:    true,
+				Default:     300,
+			},
+			"status_age": {
+				Type:        schema.TypeInt,
+				Description: "Specifies the maximum allowed lag time that the BIG-IP system accepts for the 'thisUpdate' time in the OCSP response, in seconds",
+				Optional:    true,
+				Default:     0,
+			},
+			"strict_resp_cert_check": {
+				Type:        schema.TypeString,
+				Description: "Specifies whether the responder's certificate is checked for an OCSP signing extension",
+				Optional:    true,
+				Default:     "enabled",
+			},
+			"cache_timeout": {
+				Type:        schema.TypeString,
+				Description: "Specifies the lifetime of the OCSP response in the cache, in seconds",
+				Optional:    true,
+				Default:     "indefinite",
+			},
+			"cache_error_timeout": {
+				Type:        schema.TypeInt,
+				Description: "Specifies the lifetime of an error response in the cache, in seconds. This value must be greater than connection_timeout",
+				Optional:    true,
+				Default:     3600,
+			},
+			"signer_cert": {
+				Type:        schema.TypeString,
+				Description: "Specifies a certificate used to sign an OCSP request. It should be of the pattern '/partition/cert-name'",
+				Optional:    true,
+			},
+			"signer_key": {
+				Type:        schema.TypeString,
+				Description: "Specifies a key used to sign an OCSP request. It should be of the pattern '/partition/key-name'",
+				Optional:    true,
+			},
+			"passphrase": {
+				Type:        schema.TypeString,
+				Description: "Specifies a passphrase used to sign an OCSP request",
+				Sensitive:   true,
+				Optional:    true,
+			},
+			"sign_hash": {
+				Type:        schema.TypeString,
+				Description: "Specifies the hash algorithm used to sign an OCSP request",
+				Default:     "sha256",
+				Optional:    true,
+			},
+		},
+	}
+}
+
+func resourceBigipSysOcspCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+	name := d.Get("name").(string)
+
+	ocsp := &bigip.OCSP{
+		Name: name,
+	}
+
+	populateOcspConfig(ocsp, d)
+
+	err := client.CreateOCSP(ocsp)
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(name)
+
+	if !client.Teem {
+		id := uuid.New()
+		uniqueID := id.String()
+		assetInfo := f5teem.AssetInfo{
+			Name:    "Terraform-provider-bigip",
+			Version: client.UserAgent,
+			Id:      uniqueID,
+		}
+		apiKey := os.Getenv("TEEM_API_KEY")
+		teemDevice := f5teem.AnonymousClient(assetInfo, apiKey)
+		f := map[string]interface{}{
+			"Terraform Version": client.UserAgent,
+		}
+		tsVer := strings.Split(client.UserAgent, "/")
+		err = teemDevice.Report(f, "bigip_sys_ocsp", tsVer[3])
+		if err != nil {
+			log.Printf("[ERROR]Sending Telemetry data failed:%v", err)
+		}
+	}
+
+	return resourceBigipSysOcspRead(ctx, d, meta)
+}
+
+func resourceBigipSysOcspRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+
+	id := d.Id()
+	id = strings.Trim(id, "/")
+	splitArr := strings.Split(id, "/")
+	if len(splitArr) != 2 {
+		return diag.Errorf("Invalid ID %s", id)
+	}
+
+	name := splitArr[1]
+	partition := splitArr[0]
+	ocspFqdn := fmt.Sprintf("~%s~%s", partition, name)
+
+	ocsp, err := client.GetOCSP(ocspFqdn)
+	if err != nil {
+		log.Printf("[ERROR] unable to retrieve ocsp %s: %s ", name, err)
+		return diag.FromErr(err)
+	}
+
+	ocspJson, err := json.Marshal(ocsp)
+	if err != nil {
+		log.Printf("[ERROR] unable to marshal ocsp %s: %s ", name, err)
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] ocsp response: %+v", string(ocspJson))
+
+	d.Set("name", ocsp.FullPath)
+
+	setOcspStateData(d, ocsp)
+
+	return nil
+}
+
+func resourceBigipSysOcspUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+
+	id := d.Id()
+	id = strings.Trim(id, "/")
+	splitArr := strings.Split(id, "/")
+	if len(splitArr) != 2 {
+		return diag.Errorf("Invalid ID %s", id)
+	}
+
+	name := splitArr[1]
+	partition := splitArr[0]
+	ocspFqdn := fmt.Sprintf("~%s~%s", partition, name)
+
+	ocsp := &bigip.OCSP{
+		Name: name,
+	}
+	populateOcspConfig(ocsp, d)
+
+	err := client.ModifyOCSP(ocspFqdn, ocsp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceBigipSysOcspRead(ctx, d, meta)
+}
+
+func resourceBigipSysOcspDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+
+	id := d.Id()
+	id = strings.Trim(id, "/")
+	splitArr := strings.Split(id, "/")
+	if len(splitArr) != 2 {
+		return diag.Errorf("Invalid ID %s", id)
+	}
+
+	name := splitArr[1]
+	partition := splitArr[0]
+	ocspFqdn := fmt.Sprintf("~%s~%s", partition, name)
+
+	err := client.DeleteOCSP(ocspFqdn)
+
+	if err != nil {
+		log.Printf("[ERROR] unable to delete ocsp %s: %s ", name, err)
+		return diag.FromErr(err)
+	}
+	d.SetId("")
+	return nil
+}
+
+func populateOcspConfig(ocsp *bigip.OCSP, d *schema.ResourceData) {
+	if v, ok := d.GetOk("proxy_server_pool"); ok {
+		ocsp.ProxyServerPool = v.(string)
+	}
+	if v, ok := d.GetOk("dns_resolver"); ok {
+		ocsp.DnsResolver = v.(string)
+	}
+	if v, ok := d.GetOk("concurrent_connections_limit"); ok {
+		ocsp.ConcurrentConnectionsLimit = int64(v.(int))
+	}
+	if v, ok := d.GetOk("responder_url"); ok {
+		ocsp.ResponderUrl = v.(string)
+	}
+	if v, ok := d.GetOk("route_domain"); ok {
+		ocsp.RouteDomain = v.(string)
+	}
+	if v, ok := d.GetOk("connection_timeout"); ok {
+		ocsp.ConnectionTimeout = int64(v.(int))
+	}
+	if v, ok := d.GetOk("trusted_responder"); ok {
+		ocsp.TrustedResponders = v.(string)
+	}
+	if v, ok := d.GetOk("clock_skew"); ok {
+		ocsp.ClockSkew = int64(v.(int))
+	}
+	if v, ok := d.GetOk("status_age"); ok {
+		ocsp.StatusAge = int64(v.(int))
+	}
+	if v, ok := d.GetOk("strict_resp_cert_check"); ok {
+		ocsp.StrictRespCertCheck = v.(string)
+	}
+	if v, ok := d.GetOk("cache_timeout"); ok {
+		ocsp.CacheTimeout = v.(string)
+	}
+	if v, ok := d.GetOk("cache_error_timeout"); ok {
+		ocsp.CacheErrorTimeout = int64(v.(int))
+	}
+	if v, ok := d.GetOk("signer_cert"); ok {
+		ocsp.SignerCert = v.(string)
+	}
+	if v, ok := d.GetOk("signer_key"); ok {
+		ocsp.SignerKey = v.(string)
+	}
+	if v, ok := d.GetOk("passphrase"); ok {
+		ocsp.Passphrase = v.(string)
+	}
+	if v, ok := d.GetOk("sign_hash"); ok {
+		ocsp.SignHash = v.(string)
+	}
+}
+
+func setOcspStateData(d *schema.ResourceData, ocsp *bigip.OCSP) {
+	if ocsp.ProxyServerPool != "" {
+		d.Set("proxy_server_pool", ocsp.ProxyServerPool)
+	} else {
+		d.Set("dns_resolver", ocsp.DnsResolver)
+	}
+	if ocsp.RouteDomain != "" {
+		d.Set("route_domain", ocsp.RouteDomain)
+	}
+	if ocsp.ResponderUrl != "" {
+		d.Set("responder_url", ocsp.ResponderUrl)
+	}
+	if ocsp.TrustedResponders != "" {
+		d.Set("trusted_responders", ocsp.TrustedResponders)
+	}
+	if ocsp.SignerCert != "" {
+		d.Set("signer_cert", ocsp.SignerCert)
+	}
+	if ocsp.SignerKey != "" {
+		d.Set("signer_key", ocsp.SignerKey)
+	}
+
+	d.Set("concurrent_connections_limit", ocsp.ConcurrentConnectionsLimit)
+	d.Set("clock_skew", ocsp.ClockSkew)
+	d.Set("status_age", ocsp.StatusAge)
+	d.Set("cache_timeout", ocsp.CacheTimeout)
+	d.Set("cache_error_timeout", ocsp.CacheErrorTimeout)
+	d.Set("connection_timeout", ocsp.ConnectionTimeout)
+	d.Set("strict_resp_cert_check", ocsp.StrictRespCertCheck)
+	d.Set("sign_hash", ocsp.SignHash)
+}

--- a/bigip/resource_bigip_sys_ocsp_test.go
+++ b/bigip/resource_bigip_sys_ocsp_test.go
@@ -1,0 +1,124 @@
+package bigip
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	bigip "github.com/f5devcentral/go-bigip"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+const testSysOcspDNS = `
+resource "bigip_sys_ocsp" "test-ocsp" {
+  name              = "/Common/test-ocsp"
+  dns_resolver      = "/Common/f5-aws-dns"
+  signer_key        = "/Common/le-ssl"
+  signer_cert       = "/Common/le-ssl"
+  passphrase        = "testabcdef"
+}
+`
+
+const testSysOcspProxy = `
+resource "bigip_sys_ocsp" "test-ocsp" {
+  name              = "/Common/test-ocsp"
+  proxy_server_pool = "/Common/test-poolxyz"
+  signer_key        = "/Common/le-ssl"
+  signer_cert       = "/Common/le-ssl"
+  passphrase        = "testabcdef"
+}
+`
+
+func TestAccBigipSysOCSP_create(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckOCSPDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testSysOcspDNS,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckOCSPExists("~Common~test-ocsp"),
+					resource.TestCheckResourceAttr("bigip_sys_ocsp.test-ocsp", "name", "/Common/test-ocsp"),
+					resource.TestCheckResourceAttr("bigip_sys_ocsp.test-ocsp", "dns_resolver", "/Common/f5-aws-dns"),
+					resource.TestCheckResourceAttr("bigip_sys_ocsp.test-ocsp", "signer_key", "/Common/le-ssl"),
+					resource.TestCheckResourceAttr("bigip_sys_ocsp.test-ocsp", "signer_cert", "/Common/le-ssl"),
+					resource.TestCheckResourceAttr("bigip_sys_ocsp.test-ocsp", "passphrase", "testabcdef"),
+				),
+			},
+			{
+				Config: testSysOcspProxy,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckOCSPExists("~Common~test-ocsp"),
+					resource.TestCheckResourceAttr("bigip_sys_ocsp.test-ocsp", "name", "/Common/test-ocsp"),
+					resource.TestCheckResourceAttr("bigip_sys_ocsp.test-ocsp", "proxy_server_pool", "/Common/test-poolxyz"),
+					resource.TestCheckResourceAttr("bigip_sys_ocsp.test-ocsp", "signer_key", "/Common/le-ssl"),
+					resource.TestCheckResourceAttr("bigip_sys_ocsp.test-ocsp", "signer_cert", "/Common/le-ssl"),
+					resource.TestCheckResourceAttr("bigip_sys_ocsp.test-ocsp", "passphrase", "testabcdef"),
+				),
+			},
+			{
+				Config: testSysOcspProxy,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckOCSPExists("~Common~test-ocsp"),
+					resource.TestCheckResourceAttr("bigip_sys_ocsp.test-ocsp", "name", "/Common/test-ocsp"),
+					resource.TestCheckResourceAttr("bigip_sys_ocsp.test-ocsp", "proxy_server_pool", "/Common/test-poolxyz"),
+					resource.TestCheckResourceAttr("bigip_sys_ocsp.test-ocsp", "signer_key", "/Common/le-ssl"),
+					resource.TestCheckResourceAttr("bigip_sys_ocsp.test-ocsp", "signer_cert", "/Common/le-ssl"),
+					resource.TestCheckResourceAttr("bigip_sys_ocsp.test-ocsp", "passphrase", "testabcdef"),
+				),
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func testCheckOCSPExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*bigip.BigIP)
+
+		p, err := client.GetOCSP(name)
+		if err != nil {
+			return err
+		}
+		if p == nil {
+			return fmt.Errorf("OCSP %s does not exist ", name)
+		}
+
+		return nil
+	}
+}
+
+func testCheckOCSPDestroyed(s *terraform.State) error {
+	client := testAccProvider.Meta().(*bigip.BigIP)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "bigip_sys_ocsp" {
+			continue
+		}
+
+		id := rs.Primary.ID
+		id = strings.Trim(id, "/")
+		splitArr := strings.Split(id, "/")
+		if len(splitArr) != 2 {
+			return fmt.Errorf("Invalid ID %s", id)
+		}
+
+		name := splitArr[1]
+		partition := splitArr[0]
+		ocspFqdn := fmt.Sprintf("~%s~%s", partition, name)
+		// client.DeleteOCSP(ocspFqdn)
+		ocsp, err := client.GetOCSP(ocspFqdn)
+		js, _ := json.Marshal(ocsp)
+		if err != nil {
+			return err
+		}
+		if ocsp != nil {
+			return fmt.Errorf("OCSP %s not destroyed, struct %+v, js %s", name, ocsp, string(js))
+		}
+	}
+	return nil
+}

--- a/docs/resources/bigip_ltm_profile_client_ssl.md
+++ b/docs/resources/bigip_ltm_profile_client_ssl.md
@@ -49,6 +49,8 @@ Don't insert empty fragments and No TLSv1.3 are listed as Enabled Options. `Usag
 
 * `cipher_group` - (Optional) Specifies the cipher group for the SSL server profile. It is mutually exclusive with the argument, `ciphers`. The default value is `none`.
 
+* `ocsp_stapling` - (Optional) Specifies whether the system uses OCSP stapling. The default value is `disabled`.
+
 * `peer_cert_mode` - (Optional) Specifies the way the system handles client certificates.When ignore, specifies that the system ignores certificates from client systems.When require, specifies that the system requires a client to present a valid certificate.When request, specifies that the system requests a valid certificate from a client but always authenticate the client.
 
 * `renegotiation` - (Optional) Enables or disables SSL renegotiation.When creating a new profile, the setting is provided by the parent profile

--- a/docs/resources/bigip_sys_ocsp.md
+++ b/docs/resources/bigip_sys_ocsp.md
@@ -1,0 +1,67 @@
+---
+layout: "bigip"
+page_title: "BIG-IP: bigip_sys_ocsp"
+subcategory: "System"
+description: |-
+  Provides details about OCSP resource for BIG-IP
+---
+
+# bibip\_sys\_ocsp
+
+`bigip_sys_ocsp` Manages F5 BIG-IP OCSP responder using iControl REST.
+
+## Example Usage
+
+```hcl
+resource "bigip_sys_ocsp" "test-ocsp" {
+  name              = "/Uncommon/test-ocsp"
+  proxy_server_pool = "/Common/test-poolxyz"
+  signer_key        = "/Common/le-ssl"
+  signer_cert       = "/Common/le-ssl"
+  passphrase        = "testabcdef"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required,type `string`) Name of the OCSP Responder. Name should be in pattern `/partition/ocsp_name`.
+
+* `proxy_server_pool` - (Required,type `string`) Specifies the proxy server pool the BIG-IP system uses to fetch the OCSP response.
+
+* `dns_resolver` - (Optional,type `string`) Specifies the internal DNS resolver the BIG-IP system uses to fetch the OCSP response.
+
+* `route_domain` - (Optional,type `string`) Specifies the route domain for the OCSP responder.
+
+* `concurrent_connections_limit` - (Optional,type `int`) Specifies the maximum number of connections per second allowed for the OCSP certificate validator. The default value is `50`.
+
+* `responder_url` - (Optional,type `string`) Specifies the URL of the OCSP responder.
+
+* `connection_timeout` - (Optional,type `int`) Specifies the time interval that the BIG-IP system waits for before ending the connection to the OCSP responder, in seconds. The default value is `8`.
+
+* `trusted_responders` - (Optional,type `string`) Specifies the certificates used for validating the OCSP response.
+
+* `clock_skew` - (Optional,type `int`) Specifies the time interval that the BIG-IP system allows for clock skew, in seconds. The default value is `300`.
+
+* `status_age` - (Optional,type `int`) Specifies the maximum allowed lag time that the BIG-IP system accepts for the 'thisUpdate' time in the OCSP response, in seconds. The default value is `0`.
+
+* `strict_resp_cert_check` - (Optional,type `string`) Specifies whether the responder's certificate is checked for an OCSP signing extension. The default value is `enabled`.
+
+* `cache_timeout` - (Optional,type `string`) Specifies the lifetime of the OCSP response in the cache, in seconds. The default value is `indefinite`.
+
+* `cache_error_timeout` - (Optional,type `string`) Specifies the lifetime of an error response in the cache, in seconds. This value must be greater than connection_timeout. The default value is `3600`.
+
+* `signer_cert` - (Required,type `string`) Specifies the certificate used to sign the OCSP request.
+
+* `signer_key` - (Required,type `string`) Specifies the key used to sign the OCSP request.
+
+* `passphrase` - (Optional,type `string`) Specifies a passphrase used to sign an OCSP request.
+
+* `sign_hash` - (Optional,type `string`) Specifies the hash algorithm used to sign the OCSP request. The default value is `sha256`.
+
+
+## Importing
+An existing OCSP can be imported into this resource by supplying the full path name  ex : `/partition/name`
+An example is below:
+```sh
+$ terraform import bigip_sys_ocsp.test-ocsp /Common/test-ocsp
+```

--- a/vendor/github.com/f5devcentral/go-bigip/ltm.go
+++ b/vendor/github.com/f5devcentral/go-bigip/ltm.go
@@ -130,6 +130,7 @@ type ClientSSLProfile struct {
 	Key                             string      `json:"key,omitempty"`
 	ModSslMethods                   string      `json:"modSslMethods,omitempty"`
 	Mode                            string      `json:"mode,omitempty"`
+	OcspStapling                    string      `json:"ocspStapling,omitempty"`
 	TmOptions                       interface{} `json:"tmOptions,omitempty"`
 	Passphrase                      string      `json:"passphrase,omitempty"`
 	PeerCertMode                    string      `json:"peerCertMode,omitempty"`
@@ -2100,7 +2101,7 @@ func (b *BigIP) GetClientSSLProfile(name string) (*ClientSSLProfile, error) {
 	if !ok {
 		return nil, nil
 	}
-	log.Printf("------------------ssl profile: %+v-----------------", clientSSLProfile)
+
 	return &clientSSLProfile, nil
 }
 


### PR DESCRIPTION
Added resource for creating OCSP configuration and ocsp_stapling attribute to resource_bigip_ltm_profile_ssl_client

```
go test -v ./bigip -run="TestAccBigipSysOCSP_create"
=== RUN   TestAccBigipSysOCSP_create
--- PASS: TestAccBigipSysOCSP_create (19.61s)
PASS
ok  	github.com/F5Networks/terraform-provider-bigip/bigip	19.940s
```