### PR TITLE
Added ocsp attributes for ssl_key_cert and ssl_certificate rresources

### DIFF
--- a/bigip/resource_bigip_ssl_certificate.go
+++ b/bigip/resource_bigip_ssl_certificate.go
@@ -39,13 +39,27 @@ func resourceBigipSslCertificate() *schema.Resource {
 				//ForceNew:    true,
 				Description: "Content of certificate on Disk",
 			},
-
 			"partition": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "Common",
 				Description:  "Partition of ssl certificate",
 				ValidateFunc: validatePartitionName,
+			},
+			"monitoring_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the type of monitoring used",
+			},
+			"issuer_cert": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the issuer certificate",
+			},
+			"ocsp": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the OCSP responder",
 			},
 			"full_path": {
 				Type:        schema.TypeString,
@@ -64,7 +78,19 @@ func resourceBigipSslCertificateCreate(ctx context.Context, d *schema.ResourceDa
 
 	certPath := d.Get("content").(string)
 	partition := d.Get("partition").(string)
-	err := client.UploadCertificate(name, certPath, partition)
+	cert := &bigip.Certificate{
+		Name:      name,
+		Partition: partition,
+	}
+
+	if val, ok := d.GetOk("monitoring_type"); ok {
+		cert.CertValidationOptions = []string{val.(string)}
+	}
+	if val, ok := d.GetOk("issuer_cert"); ok {
+		cert.IssuerCert = val.(string)
+	}
+
+	err := client.UploadCertificate(certPath, cert)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error in Importing certificate (%s): %s", name, err))
 	}
@@ -86,6 +112,17 @@ func resourceBigipSslCertificateCreate(ctx context.Context, d *schema.ResourceDa
 		err = teemDevice.Report(f, "bigip_ssl_certificate", tsVer[3])
 		if err != nil {
 			log.Printf("[ERROR]Sending Telemetry data failed:%v", err)
+		}
+	}
+
+	if val, ok := d.GetOk("ocsp"); ok {
+		certValidState := &bigip.CertValidatorState{Name: val.(string)}
+		certValidRef := &bigip.CertValidatorReference{}
+		certValidRef.Items = append(certValidRef.Items, *certValidState)
+		cert.CertValidatorRef = certValidRef
+		err = client.UpdateCertificate(certPath, cert)
+		if err != nil {
+			log.Printf("[ERROR]Unable to add ocsp to the certificate:%v", err)
 		}
 	}
 	return resourceBigipSslCertificateRead(ctx, d, meta)
@@ -119,6 +156,11 @@ func resourceBigipSslCertificateRead(ctx context.Context, d *schema.ResourceData
 	_ = d.Set("name", certificate.Name)
 	_ = d.Set("partition", certificate.Partition)
 	_ = d.Set("full_path", certificate.FullPath)
+	_ = d.Set("issuer_cert", certificate.IssuerCert)
+	if certificate.CertValidationOptions != nil && len(certificate.CertValidationOptions) > 0 {
+		monitor_type := certificate.CertValidationOptions[0]
+		_ = d.Set("monitoring_type", monitor_type)
+	}
 
 	return nil
 }
@@ -129,10 +171,26 @@ func resourceBigipSslCertificateUpdate(ctx context.Context, d *schema.ResourceDa
 	log.Println("[INFO] Certificate Name " + name)
 	certpath := d.Get("content").(string)
 	partition := d.Get("partition").(string)
-	/*if !strings.HasSuffix(name, ".crt") {
-		name = name + ".crt"
-	}*/
-	err := client.UpdateCertificate(name, certpath, partition)
+
+	cert := &bigip.Certificate{
+		Name:      name,
+		Partition: partition,
+	}
+
+	if val, ok := d.GetOk("monitoring_type"); ok {
+		cert.CertValidationOptions = []string{val.(string)}
+	}
+	if val, ok := d.GetOk("issuer_cert"); ok {
+		cert.IssuerCert = val.(string)
+	}
+	if val, ok := d.GetOk("ocsp"); ok {
+		certValidState := &bigip.CertValidatorState{Name: val.(string)}
+		certValidRef := &bigip.CertValidatorReference{}
+		certValidRef.Items = append(certValidRef.Items, *certValidState)
+		cert.CertValidatorRef = certValidRef
+	}
+
+	err := client.UpdateCertificate(certpath, cert)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error in Importing certificate (%s): %s", name, err))
 	}

--- a/bigip/resource_bigip_ssl_certificate_test.go
+++ b/bigip/resource_bigip_ssl_certificate_test.go
@@ -28,6 +28,17 @@ resource "bigip_ssl_certificate" "test-cert" {
 }
 `
 
+var TestSslCertOCSPResource = `
+resource "bigip_ssl_certificate" "ssl-test-certificate-tc1" {
+  name            = "test-certificate"
+  content         = "${file("` + folder + `/../examples/mycertocspv2.crt")}"
+  partition       = "Common"
+  monitoring_type = "ocsp"
+  issuer_cert     = "/Common/MyCA"
+  ocsp            = "/Common/testocsp1"
+}
+`
+
 func TestAccBigipSslCertificateImportToBigip(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -82,6 +93,29 @@ func TestAccBigipSslCertificateTCs(t *testing.T) {
 					testChecksslcertificateExists("ssl-test-certificate-tc2", true),
 					resource.TestCheckResourceAttr("bigip_ssl_certificate.ssl-test-certificate-tc1", "name", "ssl-test-certificate-tc1"),
 					resource.TestCheckResourceAttr("bigip_ssl_certificate.ssl-test-certificate-tc2", "name", "ssl-test-certificate-tc2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBigipSslCertificateOCSP(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testChecksslcertificateDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: TestSslCertOCSPResource,
+				Check: resource.ComposeTestCheckFunc(
+					testChecksslcertificateExists("test-certificate", true),
+					resource.TestCheckResourceAttr("bigip_ssl_certificate.ssl-test-certificate-tc1", "name", "test-certificate"),
+					resource.TestCheckResourceAttr("bigip_ssl_certificate.ssl-test-certificate-tc1", "partition", "Common"),
+					resource.TestCheckResourceAttr("bigip_ssl_certificate.ssl-test-certificate-tc1", "monitoring_type", "ocsp"),
+					resource.TestCheckResourceAttr("bigip_ssl_certificate.ssl-test-certificate-tc1", "issuer_cert", "/Common/MyCA"),
+					resource.TestCheckResourceAttr("bigip_ssl_certificate.ssl-test-certificate-tc1", "ocsp", "/Common/testocsp1"),
 				),
 			},
 		},

--- a/bigip/resource_bigip_ssl_key_cert_test.go
+++ b/bigip/resource_bigip_ssl_key_cert_test.go
@@ -42,6 +42,19 @@ resource "bigip_ltm_profile_server_ssl" "test-ServerSsl" {
 }
 `
 
+var sslProfileCertKeyOCSP = `
+resource "bigip_ssl_key_cert" "testkeycert" {
+  partition            = "Common"
+  key_name             = "ssl-test-key"
+  key_content          = "${file("` + folder + `/../examples/mycertocspv2.pem")}"
+  cert_name            = "ssl-test-cert"
+  cert_content         = "${file("` + folder + `/../examples/mycertocspv2.crt")}"
+  cert_monitoring_type = "ocsp"
+  issuer_cert          = "/Common/MyCA"
+  cert_ocsp            = "/Common/testocsp1"
+}
+`
+
 func TestAccBigipSSLCertKeyCreate(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -107,6 +120,28 @@ func TestAccBigipSSLCertKeyCreateCertKeyProfile(t *testing.T) {
 					resource.TestCheckResourceAttr("bigip_ssl_key_cert.testkeycert", "partition", "Common"),
 					resource.TestCheckResourceAttr("bigip_ssl_key_cert.testkeycert", "key_content", string(key2Content)),
 					resource.TestCheckResourceAttr("bigip_ssl_key_cert.testkeycert", "cert_content", string(crt2Content)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBigipSSLCertKeyCreateCertKeyProfileOCSP(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: sslProfileCertKeyOCSP,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("bigip_ssl_key_cert.testkeycert", "key_name", "ssl-test-key"),
+					resource.TestCheckResourceAttr("bigip_ssl_key_cert.testkeycert", "cert_name", "ssl-test-cert"),
+					resource.TestCheckResourceAttr("bigip_ssl_key_cert.testkeycert", "partition", "Common"),
+					resource.TestCheckResourceAttr("bigip_ssl_key_cert.testkeycert", "cert_monitoring_type", "ocsp"),
+					resource.TestCheckResourceAttr("bigip_ssl_key_cert.testkeycert", "issuer_cert", "/Common/MyCA"),
+					resource.TestCheckResourceAttr("bigip_ssl_key_cert.testkeycert", "cert_ocsp", "/Common/testocsp1"),
 				),
 			},
 		},

--- a/docs/resources/bigip_ssl_certificate.md
+++ b/docs/resources/bigip_ssl_certificate.md
@@ -33,3 +33,9 @@ resource "bigip_ssl_certificate" "test-cert" {
 * `content` - (Required) Content of certificate on Local Disk,path of SSL certificate will be provided to terraform `file` function 
 
 * `partition` - Partition on to SSL Certificate to be imported. The parameter is not required when running terraform import operation. In such case the name must be provided in full_path format.
+
+* `monitoring_type` - Specifies the type of monitoring used.
+
+* `issuer_cert` - Specifies the issuer certificate.
+
+* `ocsp` - Specifies the OCSP responder.

--- a/docs/resources/bigip_ssl_key_cert.md
+++ b/docs/resources/bigip_ssl_key_cert.md
@@ -42,6 +42,11 @@ resource "bigip_ssl_key_cert" "testkeycert" {
 
 * `passphrase` - (Optional,type `string`) Passphrase on the SSL key.
 
+* `cert_monitoring_type` - (Optional,type `string`) Specifies the type of monitoring used.
+
+* `issuer_cert` - (Optional,type `string`) Specifies the issuer certificate.
+
+* `cert_ocsp` - (Optional,type `string`) Specifies the OCSP responder.
 
 
 ## Attribute Reference


### PR DESCRIPTION
This commit is for adding ocsp attributes for ssl_cert_key and ssl_certificate resource. Closes #850 

```
> go test -v ./bigip -run="TestAccBigipSslCertificate*"
=== RUN   TestAccBigipSslCertificateImportToBigip
--- PASS: TestAccBigipSslCertificateImportToBigip (9.06s)
=== RUN   TestAccBigipSslCertificateTCs
--- PASS: TestAccBigipSslCertificateTCs (21.41s)
=== RUN   TestAccBigipSslCertificateOCSP
--- PASS: TestAccBigipSslCertificateOCSP (9.08s)
PASS
ok  	github.com/F5Networks/terraform-provider-bigip/bigip	40.688s


> go test -v ./bigip -run="TestAccBigipSSLCertKeyCreate*"
=== RUN   TestAccBigipSSLCertKeyCreate
--- PASS: TestAccBigipSSLCertKeyCreate (12.47s)
=== RUN   TestAccBigipSSLCertKeyCreateCertKeyProfile
--- PASS: TestAccBigipSSLCertKeyCreateCertKeyProfile (14.67s)
=== RUN   TestAccBigipSSLCertKeyCreateCertKeyProfileOCSP
--- PASS: TestAccBigipSSLCertKeyCreateCertKeyProfileOCSP (7.76s)
PASS
ok  	github.com/F5Networks/terraform-provider-bigip/bigip	35.701s
```