### PR TITLE
Added resource for managing partitions

### DIFF
--- a/bigip/provider.go
+++ b/bigip/provider.go
@@ -169,6 +169,7 @@ func Provider() *schema.Provider {
 			"bigip_vcmp_guest":                      resourceBigipVcmpGuest(),
 			"bigip_ltm_cipher_rule":                 resourceBigipLtmCipherRule(),
 			"bigip_ltm_cipher_group":                resourceBigipLtmCipherGroup(),
+			"bigip_partition":                       resourceBigipPartition(),
 		},
 	}
 	p.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {

--- a/bigip/resource_bigip_partition.go
+++ b/bigip/resource_bigip_partition.go
@@ -1,0 +1,138 @@
+package bigip
+
+import (
+	"context"
+	"log"
+
+	bigip "github.com/f5devcentral/go-bigip"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceBigipPartition() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBigipPartitionCreate,
+		ReadContext:   resourceBigipPartitionRead,
+		UpdateContext: resourceBigipPartitionUpdate,
+		DeleteContext: resourceBigipPartitionDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the partition",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The description of the partition",
+			},
+			"route_domain_id": {
+				Type:        schema.TypeInt,
+				Default:     0,
+				Optional:    true,
+				Description: "The route domain of the partition",
+			},
+		},
+	}
+}
+
+func resourceBigipPartitionCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*bigip.BigIP)
+	name := d.Get("name").(string)
+	routeDomain := d.Get("route_domain_id").(int)
+	description := d.Get("description").(string)
+
+	partition := &bigip.Partition{
+		Name:        name,
+		RouteDomain: routeDomain,
+	}
+
+	err := client.CreatePartition(partition)
+
+	if err != nil {
+		log.Printf("[ERROR] error while creating the partition: %s", name)
+		return diag.FromErr(err)
+	}
+
+	if description != "" {
+		descBody := make(map[string]string)
+		descBody["description"] = description
+
+		err := client.ModifyFolderDescription(name, descBody)
+
+		if err != nil {
+			log.Printf("[ERROR] error while updating the description of partition: %s", name)
+			return diag.FromErr(err)
+		}
+	}
+
+	d.SetId(name)
+	return resourceBigipPartitionRead(ctx, d, m)
+}
+
+func resourceBigipPartitionRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*bigip.BigIP)
+	name := d.Id()
+	partition, err := client.GetPartition(name)
+
+	if err != nil {
+		log.Printf("[ERROR] error while reading the partition: %s", name)
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Partition: %+v", partition)
+	d.Set("name", partition.Name)
+	d.Set("route_domain_id", partition.RouteDomain)
+
+	return nil
+}
+
+func resourceBigipPartitionUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*bigip.BigIP)
+	name := d.Id()
+	routeDomain := d.Get("route_domain_id").(int)
+
+	oldRD, newRD := d.GetChange("route_domain_id")
+	oldDesc, newDesc := d.GetChange("description")
+
+	if oldRD.(int) != newRD.(int) {
+
+		partition := &bigip.Partition{
+			RouteDomain: routeDomain,
+		}
+		err := client.ModifyPartition(name, partition)
+
+		if err != nil {
+			log.Printf("[ERROR] error while updating the partition: %s", name)
+			return diag.FromErr(err)
+		}
+	}
+	if oldDesc.(string) != newDesc.(string) {
+		descBody := make(map[string]string)
+		descBody["description"] = newDesc.(string)
+
+		err := client.ModifyFolderDescription(name, descBody)
+
+		if err != nil {
+			log.Printf("[ERROR] error while updating the description of partition: %s", name)
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceBigipPartitionRead(ctx, d, m)
+}
+
+func resourceBigipPartitionDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	name := d.Id()
+	client := m.(*bigip.BigIP)
+	err := client.DeletePartition(name)
+	if err != nil {
+		log.Printf("[ERROR] error while deleting the partition: %s", name)
+		return diag.FromErr(err)
+	}
+	return nil
+}

--- a/bigip/resource_bigip_partition_test.go
+++ b/bigip/resource_bigip_partition_test.go
@@ -1,0 +1,83 @@
+package bigip
+
+import (
+	"testing"
+
+	bigip "github.com/f5devcentral/go-bigip"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+var TEST_PARTITION_NAME = "test-partition"
+var TEST_PARTITION_RESOURCE_1 = `
+resource "bigip_partition" "test-partition" {
+  name = "` + TEST_PARTITION_NAME + `"
+  description = "created by teraform"
+  route_domain_id = 0
+}`
+
+var TEST_PARTITION_RESOURCE_2 = `
+resource "bigip_partition" "test-partition" {
+  name = "` + TEST_PARTITION_NAME + `"
+  description = "updated by teraform"
+  route_domain_id = 2
+}`
+
+func TestAccPartitionCreateUpdate(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckPartitionsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config:  TEST_PARTITION_RESOURCE_1,
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckPartitionExists(TEST_PARTITION_NAME),
+					resource.TestCheckResourceAttr("bigip_partition.test-partition", "name", TEST_PARTITION_NAME),
+					resource.TestCheckResourceAttr("bigip_partition.test-partition", "description", "created by teraform"),
+					resource.TestCheckResourceAttr("bigip_partition.test-partition", "route_domain_id", "0"),
+				),
+			},
+			{
+				Config: TEST_PARTITION_RESOURCE_2,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckPartitionExists(TEST_PARTITION_NAME),
+					resource.TestCheckResourceAttr("bigip_partition.test-partition", "name", TEST_PARTITION_NAME),
+					resource.TestCheckResourceAttr("bigip_partition.test-partition", "description", "updated by teraform"),
+					resource.TestCheckResourceAttr("bigip_partition.test-partition", "route_domain_id", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testCheckPartitionExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*bigip.BigIP)
+		partition, err := client.GetPartition(name)
+		if err != nil {
+			return err
+		}
+		if partition.Name != name {
+			return err
+		}
+		return nil
+	}
+}
+
+func testCheckPartitionsDestroyed(s *terraform.State) error {
+	client := testAccProvider.Meta().(*bigip.BigIP)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "bigip_partition" {
+			continue
+		}
+		_, err := client.GetPartition(rs.Primary.ID)
+		if err == nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/docs/resources/bigip_cm_device.md
+++ b/docs/resources/bigip_cm_device.md
@@ -23,4 +23,4 @@ resource "bigip_cm_device" "my_new_device" {
   mirror_secondary_ip = "11.11.11.11"
 }
 
-```       
+```

--- a/docs/resources/bigip_partition.md
+++ b/docs/resources/bigip_partition.md
@@ -1,0 +1,40 @@
+---
+layout: "bigip"
+page_title: "BIG-IP: bigip_partition"
+sidebar_current: "docs-bigip-resource-device-x"
+description: |-
+  Provides details about bigip_partition resource
+---
+
+# bigip_partition
+
+`bigip_partition` Manages F5 BIG-IP partitions
+
+## Example Usage
+
+```hcl
+resource "bigip_partition" "test-partition" {
+  name            = "test-partition"
+  description     = "created by terraform"
+  route_domain_id = 2
+}
+```
+
+## Argument Reference
+
+* `name` - (Required,type `string`) Name of the partition.
+
+* `description` - (Optional,type `string`) Description of the partition.
+
+* `route_domain_id` - (Optional,type `number`) Route domain id of the partition.
+
+## Importing
+
+An existing cipher group can be imported into this resource by supplying the cipher rule full path name ex : `/partition/name`
+
+An example is below:
+
+```sh
+$ terraform import bigip_partition.test_partition test_partition
+
+```

--- a/vendor/github.com/f5devcentral/go-bigip/sys.go
+++ b/vendor/github.com/f5devcentral/go-bigip/sys.go
@@ -296,6 +296,9 @@ const (
 	uriAsm             = "asm"
 	uriApm             = "apm"
 	uriAvr             = "avr"
+	uriAuth            = "auth"
+	uriPartition       = "partition"
+	uriFolder          = "folder"
 	uriIlx             = "ilx"
 	uriSyslog          = "syslog"
 	uriSnmp            = "snmp"
@@ -405,6 +408,12 @@ type Transaction struct {
 	ExecutionTimeout int64  `json:"executionTimeout,omitempty"`
 	ExecutionTime    int64  `json:"executionTime,omitempty"`
 	FailureReason    string `json:"failureReason,omitempty"`
+}
+
+type Partition struct {
+	Name        string `json:"name,omitempty"`
+	RouteDomain int    `json:"defaultRouteDomain"`
+	Description string `json:"description,omitempty"`
 }
 
 // Certificates returns a list of certificates.
@@ -1055,4 +1064,36 @@ func (b *BigIP) GetOCSP(name string) (*OCSP, error) {
 
 func (b *BigIP) DeleteOCSP(name string) error {
 	return b.delete(uriSys, "crypto", "cert-validator", "ocsp", name)
+}
+
+func (b *BigIP) CreatePartition(partition *Partition) error {
+	return b.post(partition, uriAuth, uriPartition)
+}
+
+func (b *BigIP) GetPartition(name string) (*Partition, error) {
+	var partition Partition
+	err, ok := b.getForEntity(&partition, uriAuth, uriPartition, name)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if !ok {
+		return nil, nil
+	}
+
+	return &partition, err
+}
+
+func (b *BigIP) ModifyPartition(name string, partition *Partition) error {
+	return b.patch(partition, uriAuth, uriPartition, name)
+}
+
+func (b *BigIP) DeletePartition(name string) error {
+	return b.delete(uriAuth, uriPartition, name)
+}
+
+func (b *BigIP) ModifyFolderDescription(partition string, body map[string]string) error {
+	partition = fmt.Sprintf("~%s", partition)
+	return b.patch(body, uriSys, uriFolder, partition)
 }


### PR DESCRIPTION
Added a new resource to manage partition on BIG-IP. Closes #844 

```
go test -v ./bigip -run="TestAccPartitionCreate"
=== RUN   TestAccPartitionCreate
--- PASS: TestAccPartitionCreate (13.86s)
PASS
ok  	github.com/F5Networks/terraform-provider-bigip/bigip	18.249s
```