### PR TITLE
Fix response log template, and request/response error log template variables

### DIFF
--- a/bigip/resource_bigip_ltm_profile_request_log.go
+++ b/bigip/resource_bigip_ltm_profile_request_log.go
@@ -262,13 +262,13 @@ func resourceBigipLtmProfileRequestLogRead(ctx context.Context, d *schema.Resour
 		_ = d.Set("response_logging", pp.RequestLogging)
 	}
 	if _, ok := d.GetOk("responselog_template"); ok {
-		_ = d.Set("responselog_template", pp.RequestLogTemplate)
+		_ = d.Set("responselog_template", pp.ResponseLogTemplate)
 	}
 	if _, ok := d.GetOk("requestlog_error_template"); ok {
-		_ = d.Set("requestlog_error_template", pp.RequestLogTemplate)
+		_ = d.Set("requestlog_error_template", pp.RequestLogErrorTemplate)
 	}
 	if _, ok := d.GetOk("responselog_error_template"); ok {
-		_ = d.Set("responselog_error_template", pp.RequestLogTemplate)
+		_ = d.Set("responselog_error_template", pp.ResponseLogErrorTemplate)
 	}
 	// if _, ok := d.GetOk("request_chunking"); ok {
 	// 	_ = d.Set("request_chunking", pp.RequestChunking)


### PR DESCRIPTION
The terraform variables are still set into the F5 but cause a constant real infrastructure difference.