### PR TITLE
Issue #1014 - vCMP guest virtual-disk removal works when there's more than 1 entry

### DIFF
--- a/bigip/resource_bigip_vcmp_guest.go
+++ b/bigip/resource_bigip_vcmp_guest.go
@@ -247,6 +247,7 @@ func deleteVirtualDisk(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error retrieving vCMP virtual disks: %v", err)
 	}
 
+	diskFound := false
 	for _, disk := range virtualDisks.Disks {
 		if strings.HasPrefix(disk.Name, diskName) {
 			name := strings.Replace(disk.Name, "/", "~", 1)
@@ -254,10 +255,11 @@ func deleteVirtualDisk(d *schema.ResourceData, meta interface{}) error {
 			if err != nil {
 				return fmt.Errorf("error deleting vCMP virtual disk: %v %v", diskName, err)
 			}
-		} else {
-			return fmt.Errorf("cannot find vCMP virtual disk: %v ", diskName)
+			diskFound := true
 		}
-
+	}
+	if !diskFound {
+		return fmt.Errorf("cannot find vCMP virtual disk: %v ", diskName)
 	}
 	return nil
 }


### PR DESCRIPTION
Loop through all virtual disks before failing with "cannot find vCMP virtual disk" error.

https://github.com/F5Networks/terraform-provider-bigip/issues/1014 

