### PR TITLE
Fix handling of single quotes in shell commands

### DIFF
--- a/bigip/resource_bigip_command.go
+++ b/bigip/resource_bigip_command.go
@@ -61,7 +61,9 @@ func resourceBigipCommandCreate(ctx context.Context, d *schema.ResourceData, met
 	if d.Get("when").(string) == "apply" {
 		if m, ok := d.GetOk("commands"); ok {
 			for _, cmd := range m.([]interface{}) {
-				commandList = append(commandList, fmt.Sprintf("-c 'tmsh %s'", cmd.(string)))
+				// Handle edge case where command contains our quote character
+				escapedCmd := strings.ReplaceAll(cmd.(string), "'", "'\\''")
+				commandList = append(commandList, fmt.Sprintf("-c 'tmsh %s'", escapedCmd))
 			}
 		}
 		log.Printf("[INFO] Running TMSH Command : %v ", commandList)


### PR DESCRIPTION
Previously, if a command in the `bigip_command` resource contained single quotes, the constructed shell command would have unbalanced quotes, leading to syntax errors and command execution failures. This commit fixes the issue by escaping single quotes within the commands before wrapping them in single quotes. This ensures that all commands are properly formatted and executed, even if they contain single quotes.

- Escape single quotes in commands before constructing the shell command
- Prevents syntax errors due to unbalanced quotes
- Enhances security by mitigating potential command injection risks