### PR TITLE
Docs fix for punctuation and duplicates

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,7 @@ provider "bigip" {
 - `login_ref` - (Optional,Default `tmos`) Login reference for token authentication (see BIG-IP REST docs for details). May be set via the `BIGIP_LOGIN_REF` environment variable.
 - `port` - (Optional) Management Port to connect to BIG-IP,this is mainly required if we have single nic BIG-IP in AWS/Azure/GCP (or) Management port other than `443`. Can be set via `BIGIP_PORT` environment variable.
 - `validate_certs_disable` - (Optional, Default `true`) If set to true, Disables TLS certificate check on BIG-IP. Can be set via the `BIGIP_VERIFY_CERT_DISABLE` environment variable.
-- `trusted_cert_path` - (type `string`) Provides Certificate Path to be used TLS Validate.It will be required only if `validate_certs_disable` set to `false`.Can be set via the `BIGIP_TRUSTED_CERT_PATH` environment variable.
+- `trusted_cert_path` - (type `string`) Provides Certificate Path to be used TLS Validate. It will be required only if `validate_certs_disable` set to `false`. Can be set via the `BIGIP_TRUSTED_CERT_PATH` environment variable.
 
 ~> **Note** For BIG-IQ resources these provider credentials `address`,`username`,`password` can be set to BIG-IQ credentials.
 

--- a/docs/resources/bigip_as3.md
+++ b/docs/resources/bigip_as3.md
@@ -127,19 +127,19 @@ resource "bigip_as3" "as3-example1" {
 
 * `controls` - (Optional) - A map that allows you to configure specific behavior controls for the AS3 declaration. Each key represents a particular control setting, and the corresponding value defines its configuration.
 
-    * `dry_run` (Optional) -  Enables or disables dry-run mode.
+    * `dry_run` - (Optional) -  Enables or disables dry-run mode.
       * Allowed values: "yes", "no"
 
-   * `trace` (Optional) - Enables or disables detailed trace of the configuration process.
+   * `trace` - (Optional) - Enables or disables detailed trace of the configuration process.
      * Allowed values: "yes", "no"
 
-   * `trace_response` (Optional) - If set to "yes" the response will contain the trace files.
+   * `trace_response` - (Optional) - If set to "yes" the response will contain the trace files.
      * Allowed values: "yes", "no"
 
-   * `log_level` (Optional) - Controls the amount of detail in logs produced while configuring the Tenant.
+   * `log_level` - (Optional) - Controls the amount of detail in logs produced while configuring the Tenant.
      * Allowed values: "emergency", "alert", "critical", "error", "warning", "notice", "info", "debug"
 
-   * `user_agent` (Optional) - Controls the User Agent information to include in TEEM report.
+   * `user_agent` - (Optional) - Controls the User Agent information to include in TEEM report.
 
 
 * `application_list` - (Optional) - List of applications currently deployed on the Big-Ip

--- a/docs/resources/bigip_do.md
+++ b/docs/resources/bigip_do.md
@@ -28,19 +28,19 @@ resource "bigip_do" "do-example" {
 
 * `do_json` - (Required) Name of the of the Declarative DO JSON file
  
-* `bigip_address` - (optional) IP Address of BIGIP Host to be used for this resource,this is optional parameter.
+* `bigip_address` - (Optional) IP Address of BIGIP Host to be used for this resource,this is optional parameter.
 whenever we specify this parameter it gets overwrite provider configuration
 
-* `bigip_user` - (optional) UserName of BIGIP host to be used for this resource,this is optional parameter.
+* `bigip_user` - (Optional) UserName of BIGIP host to be used for this resource,this is optional parameter.
 whenever we specify this parameter it gets overwrite provider configuration
 
-* `bigip_port` - (optional) Port number of BIGIP host to be used for this resource,this is optional parameter.
+* `bigip_port` - (Optional) Port number of BIGIP host to be used for this resource,this is optional parameter.
 whenever we specify this parameter it gets overwrite provider configuration
 
-* `bigip_password` - (optional) Password of  BIGIP host to be used for this resource,this is optional parameter.
+* `bigip_password` - (Optional) Password of  BIGIP host to be used for this resource,this is optional parameter.
 whenever we specify this parameter it gets overwrite provider configuration
 
-* `timeout(minutes)` - (optional) timeout to keep polling DO endpoint until Bigip is provisioned by DO.( Default timeout is 20 minutes )
+* `timeout(minutes)` - (Optional) timeout to keep polling DO endpoint until Bigip is provisioned by DO.( Default timeout is 20 minutes )
 
 ~> **Note:** If we want to replace provider BIGIP with other BIGIPs details we can specify with `bigip_address`,
 `bigip_user`,`bigip_port` and `bigip_password`. All Must be specified in such scenario.

--- a/docs/resources/bigip_fast_http_app.md
+++ b/docs/resources/bigip_fast_http_app.md
@@ -107,9 +107,9 @@ This IP address, combined with the port you specify below, becomes the BIG-IP vi
 
 The `virtual_server` block supports the following:
 
-* `ip` - (Optional , `string`) IP4/IPv6 address to be used for virtual server ex: `10.1.1.1`
+* `ip` - (Optional, `string`) IP4/IPv6 address to be used for virtual server ex: `10.1.1.1`
 
-* `port` -(Optional , `int`) Port number to used for accessing virtual server/application
+* `port` -(Optional, `int`) Port number to used for accessing virtual server/application
 
 ### Pool Members
 
@@ -117,15 +117,15 @@ Using this block will `enable` for FAST-Generated Pool.
 
 The `pool_members` block supports the following:
 
-* `addresses` - (Optional , `list`) List of server address to be used for FAST-Generated Pool.
+* `addresses` - (Optional, `list`) List of server address to be used for FAST-Generated Pool.
 
-* `port` - (Optional , `int`) port number of serviceport to be used for FAST-Generated Pool.
+* `port` - (Optional, `int`) port number of serviceport to be used for FAST-Generated Pool.
 
-* `connection_limit` - (Optional , `int`) connectionLimit value to be used for FAST-Generated Pool.
+* `connection_limit` - (Optional, `int`) connectionLimit value to be used for FAST-Generated Pool.
 
-* `priority_group` - (Optional , `int`) priorityGroup value to be used for FAST-Generated Pool.
+* `priority_group` - (Optional, `int`) priorityGroup value to be used for FAST-Generated Pool.
 
-* `share_nodes` - (Optional , `bool`) shareNodes value to be used for FAST-Generated Pool.
+* `share_nodes` - (Optional, `bool`) shareNodes value to be used for FAST-Generated Pool.
 
 
 ### Pool Monitor
@@ -134,21 +134,21 @@ Using this block will `enable` for FAST-Generated Pool Monitor.
 
 The `monitor` block supports the following:
 
-* `monitor_auth` - (Optional , `bool`) set `true` if the servers require login credentials for web access on FAST-Generated Pool Monitor. default is `false`.
+* `monitor_auth` - (Optional, `bool`) set `true` if the servers require login credentials for web access on FAST-Generated Pool Monitor. default is `false`.
 
-* `username` - (Optional , `string`) username for web access on FAST-Generated Pool Monitor.
+* `username` - (Optional, `string`) username for web access on FAST-Generated Pool Monitor.
 
-* `password` - (Optional , `string`) password for web access on FAST-Generated Pool Monitor.
+* `password` - (Optional, `string`) password for web access on FAST-Generated Pool Monitor.
 
-* `interval` - (Optional , `int`) Set the time between health checks,in seconds for FAST-Generated Pool Monitor. 
+* `interval` - (Optional, `int`) Set the time between health checks,in seconds for FAST-Generated Pool Monitor. 
 
-* `send_string` - (Optional , `string`) Specify data to be sent during each health check for FAST-Generated Pool Monitor.
+* `send_string` - (Optional, `string`) Specify data to be sent during each health check for FAST-Generated Pool Monitor.
 
-* `response` - (Optional , `string`) The presence of this string anywhere in the HTTP response implies availability.
+* `response` - (Optional, `string`) The presence of this string anywhere in the HTTP response implies availability.
 
 ### WAF Security policy
 Using this block will `enable` for FAST-Generated WAF Security Policy
 
 The `waf_security_policy` block supports the following:
 
-* `enable` - (Optional , `bool`) Setting `true` will enable FAST to create WAF Security Policy.
+* `enable` - (Optional, `bool`) Setting `true` will enable FAST to create WAF Security Policy.

--- a/docs/resources/bigip_fast_https_app.md
+++ b/docs/resources/bigip_fast_https_app.md
@@ -122,9 +122,9 @@ This IP address, combined with the port you specify below, becomes the BIG-IP vi
 
 The `virtual_server` block supports the following:
 
-* `ip` - (Optional , `string`) IP4/IPv6 address to be used for virtual server ex: `10.1.1.1`
+* `ip` - (Optional, `string`) IP4/IPv6 address to be used for virtual server ex: `10.1.1.1`
 
-* `port` -(Optional , `int`) Port number to used for accessing virtual server/application
+* `port` -(Optional, `int`) Port number to used for accessing virtual server/application
 
 
 ### TLS Server Profile
@@ -158,15 +158,15 @@ Using this block will `enable` for FAST-Generated Pool.
 
 The `pool_members` block supports the following:
 
-* `addresses` - (Optional , `list`) List of server address to be used for FAST-Generated Pool.
+* `addresses` - (Optional, `list`) List of server address to be used for FAST-Generated Pool.
 
-* `port` - (Optional , `int`) port number of serviceport to be used for FAST-Generated Pool.
+* `port` - (Optional, `int`) port number of serviceport to be used for FAST-Generated Pool.
 
-* `connection_limit` - (Optional , `int`) connectionLimit value to be used for FAST-Generated Pool.
+* `connection_limit` - (Optional, `int`) connectionLimit value to be used for FAST-Generated Pool.
 
-* `priority_group` - (Optional , `int`) priorityGroup value to be used for FAST-Generated Pool.
+* `priority_group` - (Optional, `int`) priorityGroup value to be used for FAST-Generated Pool.
 
-* `share_nodes` - (Optional , `bool`) shareNodes value to be used for FAST-Generated Pool.
+* `share_nodes` - (Optional, `bool`) shareNodes value to be used for FAST-Generated Pool.
 
 
 ### Pool Monitor
@@ -175,14 +175,14 @@ Using this block will `enable` for FAST-Generated Pool Monitor.
 
 The `monitor` block supports the following:
 
-* `monitor_auth` - (Optional , `bool`) set `true` if the servers require login credentials for web access on FAST-Generated Pool Monitor. default is `false`.
+* `monitor_auth` - (Optional, `bool`) set `true` if the servers require login credentials for web access on FAST-Generated Pool Monitor. default is `false`.
 
-* `username` - (Optional , `string`) username for web access on FAST-Generated Pool Monitor.
+* `username` - (Optional, `string`) username for web access on FAST-Generated Pool Monitor.
 
-* `password` - (Optional , `string`) password for web access on FAST-Generated Pool Monitor.
+* `password` - (Optional, `string`) password for web access on FAST-Generated Pool Monitor.
 
-* `interval` - (Optional , `int`) Set the time between health checks,in seconds for FAST-Generated Pool Monitor. 
+* `interval` - (Optional, `int`) Set the time between health checks,in seconds for FAST-Generated Pool Monitor. 
 
-* `send_string` - (Optional , `string`) Specify data to be sent during each health check for FAST-Generated Pool Monitor.
+* `send_string` - (Optional, `string`) Specify data to be sent during each health check for FAST-Generated Pool Monitor.
 
-* `response` - (Optional , `string`) The presence of this string anywhere in the HTTP response implies availability.
+* `response` - (Optional, `string`) The presence of this string anywhere in the HTTP response implies availability.

--- a/docs/resources/bigip_ipsec_policy.md
+++ b/docs/resources/bigip_ipsec_policy.md
@@ -31,7 +31,7 @@ resource "bigip_ipsec_policy" "test-policy" {
 ```      
 
 ## Argument Reference
-* `name` - (Required) Name of the IPSec policy,it should be "full path".The full path is the combination of the partition + name of the IPSec policy.(For example `/Common/test-policy`)
+* `name` - (Required) Name of the IPSec policy, it should be "full path". The full path is the combination of the partition + name of the IPSec policy (For example `/Common/test-policy`).
 
 * `description` - (Optional,type `string`) Description of the IPSec policy.
 
@@ -56,4 +56,4 @@ resource "bigip_ipsec_policy" "test-policy" {
 * `perfect_forward_secrecy` - (Optional, type `string`) Specifies the Diffie-Hellman group to use for IKE Phase 2 negotiation. Valid choices are: `none, modp768, modp1024, modp1536, modp2048, modp3072,
   modp4096, modp6144, modp8192`
 
-* `ipcomp` - (Optional, type `string`) Specifies whether to use IPComp encapsulation. Valid choices are: `none", null", deflate`
+* `ipcomp` - (Optional, type `string`) Specifies whether to use IPComp encapsulation. Valid choices are: `none, null, deflate`

--- a/docs/resources/bigip_ipsec_profile.md
+++ b/docs/resources/bigip_ipsec_profile.md
@@ -23,7 +23,7 @@ resource "bigip_ipsec_profile" "azurevWAN_profile" {
 
 ## Argument Reference
 
-* `name` - (Required) Displays the name of the IPsec interface tunnel profile,it should be "full path".The full path is the combination of the partition + name of the IPSec profile.(For example `/Common/test-profile`)
+* `name` - (Required) Displays the name of the IPsec interface tunnel profile, it should be "full path". The full path is the combination of the partition + name of the IPSec profile (For example `/Common/test-profile`).
 
 * `description` - (Optional,type `string`) Specifies descriptive text that identifies the IPsec interface tunnel profile.
 

--- a/docs/resources/bigip_ltm_monitor.md
+++ b/docs/resources/bigip_ltm_monitor.md
@@ -59,7 +59,7 @@ resource "bigip_ltm_monitor" "test-postgresql-monitor" {
 
 ## Argument Reference
 
-* `name` ((Required,type `string`) Specifies the Name of the LTM Monitor.Name of Monitor should be full path,full path is the combination of the `partition + monitor name`,For ex:`/Common/test-ltm-monitor`.
+* `name` ((Required,type `string`) Specifies the Name of the LTM Monitor. Name of Monitor should be full path, full path is the combination of the `partition + monitor name`, for ex:`/Common/test-ltm-monitor`.
 
 * `parent` - (Required,type `string`)  Parent monitor for the system to use for setting initial values for the new monitor.
 

--- a/docs/resources/bigip_ltm_persistence_profile_cookie.md
+++ b/docs/resources/bigip_ltm_persistence_profile_cookie.md
@@ -39,38 +39,38 @@ resource "bigip_ltm_persistence_profile_cookie" "test_ppcookie" {
 
 `name` - (Required) Name of the virtual address
 
-`defaults_from` - (Required) Parent cookie persistence profile
+`defaults_from` - (Required) Specifies the existing profile from which the system imports settings for the new profile
 
-`match_across_pools` (Optional) (enabled or disabled) match across pools with given persistence record
+`match_across_pools` - (Optional) (enabled or disabled) match across pools with given persistence record
 
-`match_across_services` (Optional) (enabled or disabled) match across services with given persistence record
+`match_across_services` - (Optional) (enabled or disabled) match across services with given persistence record
 
-`match_across_virtuals` (Optional) (enabled or disabled) match across virtual servers with given persistence record
+`match_across_virtuals` - (Optional) (enabled or disabled) match across virtual servers with given persistence record
 
-`method` (Optional) Specifies the type of cookie processing that the system uses. The default value is insert
+`method` - (Optional) Specifies the type of cookie processing that the system uses. The default value is insert
 
-`mirror` (Optional) (enabled or disabled) mirror persistence record
+`mirror` - (Optional) (enabled or disabled) mirror persistence record
 
-`timeout` (Optional) (enabled or disabled) Timeout for persistence of the session in seconds
+`timeout` - (Optional) (enabled or disabled) Timeout for persistence of the session in seconds
 
-`override_conn_limit` (Optional) (enabled or disabled) Enable or dissable pool member connection limits are overridden for persisted clients. Per-virtual connection limits remain hard limits and are not overridden.
+`override_conn_limit` - (Optional) (enabled or disabled) Enable or dissable pool member connection limits are overridden for persisted clients. Per-virtual connection limits remain hard limits and are not overridden.
 
-`always_send` (Optional) (enabled or disabled) always send cookies
+`always_send` - (Optional) (enabled or disabled) always send cookies
 
-`cookie_encryption` (Optional) (required, preferred, or disabled) To required, preferred, or disabled policy for cookie encryption
+`cookie_encryption` - (Optional) (required, preferred, or disabled) To required, preferred, or disabled policy for cookie encryption
 
-`cookie_encryption_passphrase` (Optional) (required, preferred, or disabled) Passphrase for encrypted cookies. The field is encrypted on the server and will always return differently then set.
+`cookie_encryption_passphrase` - (Optional) (required, preferred, or disabled) Passphrase for encrypted cookies. The field is encrypted on the server and will always return differently then set.
 If this is configured specify `ignore_changes` under the `lifecycle` block to ignore returned encrypted value.
 
-`cookie_name` (Optional) Name of the cookie to track persistence
+`cookie_name` - (Optional) Name of the cookie to track persistence
 
-`expiration` (Optional) Expiration TTL for cookie specified in DAY:HOUR:MIN:SECONDS (Examples: 1:0:0:0 one day, 1:0:0 one hour, 30:0 thirty minutes)
+`expiration` - (Optional) Expiration TTL for cookie specified in DAY:HOUR:MIN:SECONDS (Examples: 1:0:0:0 one day, 1:0:0 one hour, 30:0 thirty minutes)
 
-`hash_length` (Optional) (Integer) Length of hash to apply to cookie
+`hash_length` - (Optional) (Integer) Length of hash to apply to cookie
 
-`hash_offset` (Optional) (Integer) Number of characters to skip in the cookie for the hash
+`hash_offset` - (Optional) (Integer) Number of characters to skip in the cookie for the hash
 
-`httponly` (Optional) (enabled or disabled) Sending only over http
+`httponly` - (Optional) (enabled or disabled) Sending only over http
 
 ## Importing
 An cookie persistence profile can be imported into this resource by supplying the Name in `full path` as `id`.

--- a/docs/resources/bigip_ltm_persistence_profile_srcaddr.md
+++ b/docs/resources/bigip_ltm_persistence_profile_srcaddr.md
@@ -32,25 +32,25 @@ resource "bigip_ltm_persistence_profile_srcaddr" "srcaddr" {
 
 `name` - (Required) Name of the virtual address
 
-`defaults_from` - (Required) Parent cookie persistence profile
+`defaults_from` - (Required) Specifies the existing profile from which the system imports settings for the new profile
 
-`match_across_pools` (Optional) (enabled or disabled) match across pools with given persistence record
+`match_across_pools` - (Optional) (enabled or disabled) match across pools with given persistence record
 
-`match_across_services` (Optional) (enabled or disabled) match across services with given persistence record
+`match_across_services` - (Optional) (enabled or disabled) match across services with given persistence record
 
-`match_across_virtuals` (Optional) (enabled or disabled) match across virtual servers with given persistence record
+`match_across_virtuals` - (Optional) (enabled or disabled) match across virtual servers with given persistence record
 
-`mirror` (Optional) (enabled or disabled) mirror persistence record
+`mirror` - (Optional) (enabled or disabled) mirror persistence record
 
-`timeout` (Optional) (enabled or disabled) Timeout for persistence of the session in seconds
+`timeout` - (Optional) (enabled or disabled) Timeout for persistence of the session in seconds
 
-`override_conn_limit` (Optional) (enabled or disabled) Enable or dissable pool member connection limits are overridden for persisted clients. Per-virtual connection limits remain hard limits and are not overridden.
+`override_conn_limit` - (Optional) (enabled or disabled) Enable or dissable pool member connection limits are overridden for persisted clients. Per-virtual connection limits remain hard limits and are not overridden.
 
-`hash_algorithm` (Optional) Specify the hash algorithm
+`hash_algorithm` - (Optional) Specify the hash algorithm
 
-`mask` (Optional) Identify a range of source IP addresses to manage together as a single source address affinity persistent connection when connecting to the pool. Must be a valid IPv4 or IPv6 mask.
+`mask` - (Optional) Identify a range of source IP addresses to manage together as a single source address affinity persistent connection when connecting to the pool. Must be a valid IPv4 or IPv6 mask.
 
-`map_proxies` (Optional) (enabled or disabled) Directs all to the same single pool member
+`map_proxies` - (Optional) (enabled or disabled) Directs all to the same single pool member
 
 ## Importing
 An source-addr persistence profile can be imported into this resource by supplying the Name in `full path` as `id`.

--- a/docs/resources/bigip_ltm_persistence_profile_ssl.md
+++ b/docs/resources/bigip_ltm_persistence_profile_ssl.md
@@ -29,19 +29,19 @@ resource "bigip_ltm_persistence_profile_ssl" "ppssl" {
 
 `name` - (Required) Name of the virtual address
 
-`defaults_from` - (Required) Parent cookie persistence profile
+`defaults_from` - (Required) Specifies the existing profile from which the system imports settings for the new profile
 
-`match_across_pools` (Optional) (enabled or disabled) match across pools with given persistence record
+`match_across_pools` - (Optional) (enabled or disabled) match across pools with given persistence record
 
-`match_across_services` (Optional) (enabled or disabled) match across services with given persistence record
+`match_across_services` - (Optional) (enabled or disabled) match across services with given persistence record
 
-`match_across_virtuals` (Optional) (enabled or disabled) match across virtual servers with given persistence record
+`match_across_virtuals` - (Optional) (enabled or disabled) match across virtual servers with given persistence record
 
-`mirror` (Optional) (enabled or disabled) mirror persistence record
+`mirror` - (Optional) (enabled or disabled) mirror persistence record
 
-`timeout` (Optional) (enabled or disabled) Timeout for persistence of the session in seconds
+`timeout` - (Optional) (enabled or disabled) Timeout for persistence of the session in seconds
 
-`override_conn_limit` (Optional) (enabled or disabled) Enable or dissable pool member connection limits are overridden for persisted clients. Per-virtual connection limits remain hard limits and are not overridden.
+`override_conn_limit` - (Optional) (enabled or disabled) Enable or dissable pool member connection limits are overridden for persisted clients. Per-virtual connection limits remain hard limits and are not overridden.
 
 ## Importing
 An ssl persistence profile can be imported into this resource by supplying the Name in `full path` as `id`.

--- a/docs/resources/bigip_ltm_pool.md
+++ b/docs/resources/bigip_ltm_pool.md
@@ -30,7 +30,7 @@ resource "bigip_ltm_pool" "pool" {
 
 ## Argument Reference
 
-* `name` - (Required,type `string`) Name of the pool,it should be `full path`.The full path is the combination of the `partition + name` of the pool.(For example `/Common/my-pool`)
+* `name` - (Required,type `string`) Name of the pool, it should be `full path`. The full path is the combination of the `partition + name` of the pool (For example `/Common/my-pool`).
 
 * `monitors` - (Optional,type `list`) List of monitor names to associate with the pool
 

--- a/docs/resources/bigip_ltm_pool_attachment.md
+++ b/docs/resources/bigip_ltm_pool_attachment.md
@@ -107,11 +107,11 @@ resource "bigip_ltm_pool_attachment" "k8sprod" {
 
 ## Argument Reference
 
-* `pool` - (Required) Name of the pool to which members should be attached,it should be "full path".The full path is the combination of the partition + name of the pool.(For example `/Common/my-pool`) or partition + directory + name of the pool (For example `/Common/test/my-pool`).When including directory in fullpath we have to make sure it is created in the given partition before using it.
+* `pool` - (Required) Name of the pool to which members should be attached,it should be "full path". The full path is the combination of the partition + name of the pool (For example `/Common/my-pool`) or partition + directory + name of the pool (For example `/Common/test/my-pool`). When including directory in fullpath we have to make sure it is created in the given partition before using it.
 
 * `node` - (Required) Pool member address/fqdn with service port, (ex: `1.1.1.1:80/www.google.com:80`). (Note: Member will be in same partition of Pool)
 
-* `connection_limit` - (Optional) Specifies a maximum established connection limit for a pool member or node.The default is 0, meaning that there is no limit to the number of connections.
+* `connection_limit` - (Optional) Specifies a maximum established connection limit for a pool member or node. The default is 0, meaning that there is no limit to the number of connections.
 
 * `connection_rate_limit` - (Optional) Specifies the maximum number of connections-per-second allowed for a pool member,The default is 0.
 

--- a/docs/resources/bigip_ltm_profile_bot_defence.md
+++ b/docs/resources/bigip_ltm_profile_bot_defence.md
@@ -23,11 +23,11 @@ resource "bigip_ltm_profile_bot_defense" "test-bot-tc1" {
 
 ## Argument Reference
 
-* `name` (Required,type `string`) Name of the Bot Defense profile,name of Profile should be full path. Full path is the combination of the `partition + profile name`,For example `/Common/test-bot-tc1`.
+* `name` - (Required,type `string`) Name of the Bot Defense profile, name of Profile should be full path. Full path is the combination of the `partition + profile name`, for example `/Common/test-bot-tc1`.
 
-* `defaults_from` - (optional,type `string`) Specifies the profile from which this profile inherits settings. The default is the system-supplied `bot-defense` profile.
+* `defaults_from` - (Optional,type `string`) Specifies the profile from which this profile inherits settings. The default is the system-supplied `bot-defense` profile.
 
-* `description` - (optional,type `string`) Specifies user-defined description.
+* `description` - (Optional,type `string`) Specifies user-defined description.
 
 * `template` - (Optional,type `string`) Profile templates specify Mitigation and Verification Settings default values. possible ptions `balanced`,`relaxed` and `strict`.
 

--- a/docs/resources/bigip_ltm_profile_client_ssl.md
+++ b/docs/resources/bigip_ltm_profile_client_ssl.md
@@ -25,7 +25,7 @@ resource "bigip_ltm_profile_client_ssl" "test-ClientSsl" {
 
 ## Argument Reference
 
-* `name` (Required,type `string`) Specifies the name of the profile.Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-clientssl-profile`.
+* `name` - (Required,type `string`) Specifies the name of the profile. Name of Profile should be full path. The full path is the combination of the `partition + profile name`, for example `/Common/test-clientssl-profile`.
 
 * `defaults_from` - (Optional) Parent profile for this clientssl profile.Once this value has been set, it cannot be changed. Default value is `/Common/clientssl`. It Should Full path `/partition/profile_name`
 
@@ -83,13 +83,13 @@ There can be only one SSL profile with this setting enabled.
 
 * `ssl_forward_proxy_bypass` - (Optional) Specifies whether SSL forward proxy bypass feature is enabled or not. The default value is disabled.
 
-* `ssl_c3d` (Optional) Enables or disables SSL client certificate constrained delegation. The default option is disabled. Conversely, you can specify enabled to use the SSL client certificate constrained delegation.
+* `ssl_c3d` - (Optional) Enables or disables SSL client certificate constrained delegation. The default option is disabled. Conversely, you can specify enabled to use the SSL client certificate constrained delegation.
   
-* `c3d_client_fallback_cert` (Optional) Specifies the client certificate to use in SSL client certificate constrained delegation. This certificate will be used if client does not provide a cert during the SSL handshake. The default value is none.
+* `c3d_client_fallback_cert` - (Optional) Specifies the client certificate to use in SSL client certificate constrained delegation. This certificate will be used if client does not provide a cert during the SSL handshake. The default value is none.
 
-* `c3d_drop_unknown_ocsp_status` (Optional) Specifies the BIG-IP action when the OCSP responder returns unknown status. The default value is drop, which causes the onnection to be dropped. Conversely, you can specify ignore, which causes the connection to ignore the unknown status and continue.
+* `c3d_drop_unknown_ocsp_status` - (Optional) Specifies the BIG-IP action when the OCSP responder returns unknown status. The default value is drop, which causes the onnection to be dropped. Conversely, you can specify ignore, which causes the connection to ignore the unknown status and continue.
 
-* `c3d_ocsp` (Optional) Specifies the SSL client certificate constrained delegation OCSP object that the BIG-IP SSL should use to connect to the OCSP responder and check the client certificate status.
+* `c3d_ocsp` - (Optional) Specifies the SSL client certificate constrained delegation OCSP object that the BIG-IP SSL should use to connect to the OCSP responder and check the client certificate status.
 
 
 ## Importing

--- a/docs/resources/bigip_ltm_profile_fasthttp.md
+++ b/docs/resources/bigip_ltm_profile_fasthttp.md
@@ -34,7 +34,7 @@ resource "bigip_ltm_profile_fasthttp" "sjfasthttpprofile" {
 
 ## Argument Reference
 
-* `name` (Required) Name of the profile_fasthttp
+* `name` - (Required) Name of the profile_fasthttp
 
 * `defaults_from` - (Optional) Specifies the profile that you want to use as the parent profile. Your new profile inherits all settings and values from the parent profile specified.
 

--- a/docs/resources/bigip_ltm_profile_fastl4.md
+++ b/docs/resources/bigip_ltm_profile_fastl4.md
@@ -32,7 +32,7 @@ resource "bigip_ltm_profile_fastl4" "profile_fastl4" {
 
 ## Argument Reference
 
-* `name` (Required,type `string`) Name of the LTM fastL4 Profile.The full path is the combination of the `partition + name` of the resource (For example `/Common/my-fastl4profile`) or  `partition + directory + name` of the resource  (example: `/Common/test/my-fastl4profile`)
+* `name` - (Required,type `string`) Name of the LTM fastL4 Profile. The full path is the combination of the `partition + name` of the resource (For example `/Common/my-fastl4profile`) or  `partition + directory + name` of the resource  (example: `/Common/test/my-fastl4profile`)
 
 * `defaults_from` - (Optional,type `string`) Specifies the profile that you want to use as the parent profile. Your new profile inherits all settings and values from the parent profile specified.
 

--- a/docs/resources/bigip_ltm_profile_ftp.md
+++ b/docs/resources/bigip_ltm_profile_ftp.md
@@ -47,7 +47,7 @@ resource "bigip_ltm_profile_ftp" "sanjose-ftp-profile" {
 
 ## Argument Reference
 
-* `name` (Required) Name of the profile_ftp
+* `name` - (Required) Name of the profile_ftp
 
 * `partition` - (Optional) Displays the administrative partition within which this profile resides
 
@@ -62,31 +62,31 @@ https://support.f5.com/csp/article/K08859735
 
 * `enforce_tlssession_reuse` - (Optional) Specifies, when selected (enabled), that the system enforces the data connection to reuse a TLS session. The default value is unchecked (disabled)
 
-* `allow_active_mode` - (Optional)Specifies, when selected (enabled), that the system allows FTP Active Transfer mode. The default value is enabled
+* `allow_active_mode` - (Optional) Specifies, when selected (enabled), that the system allows FTP Active Transfer mode. The default value is enabled
 
 
 
 ### Arguments which are updated/available in Bigip versions (12.x - 13.x) for FTP profile.For more information refer below KB article
 https://support.f5.com/csp/article/K13044205
 
-* `allow_ftps` - (Optional)Allow explicit FTPS negotiation. The default is disabled.When enabled (selected), that the system allows explicit FTPS negotiation for SSL or TLS. 
+* `allow_ftps` - (Optional) Allow explicit FTPS negotiation. The default is disabled.When enabled (selected), that the system allows explicit FTPS negotiation for SSL or TLS. 
 
-* `translate_extended` - (Optional)Specifies, when selected (enabled), that the system uses ensures compatibility between IP version 4 and IP version 6 clients and servers when using the FTP protocol. The default is selected (enabled).
+* `translate_extended` - (Optional) Specifies, when selected (enabled), that the system uses ensures compatibility between IP version 4 and IP version 6 clients and servers when using the FTP protocol. The default is selected (enabled).
 
 
 
 ## Common Arguments for all versions
 
-* `security` - (Optional)Specifies, when checked (enabled), that the system inspects FTP traffic for security vulnerabilities using an FTP security profile. This option is available only on systems licensed for BIG-IP ASM.
+* `security` - (Optional) Specifies, when checked (enabled), that the system inspects FTP traffic for security vulnerabilities using an FTP security profile. This option is available only on systems licensed for BIG-IP ASM.
 
-* `port` - (Optional)Allows you to configure the FTP service to run on an alternate port. The default is 20.
+* `port` - (Optional) Allows you to configure the FTP service to run on an alternate port. The default is 20.
 
-* `log_profile` - (Optional)Configures the ALG log profile that controls logging
+* `log_profile` - (Optional) Configures the ALG log profile that controls logging
 
-* `log_publisher` - (Optional)Configures the log publisher that handles events logging for this profile
+* `log_publisher` - (Optional) Configures the log publisher that handles events logging for this profile
 
-*  `inherit_parent_profile` - (Optional)Enables the FTP data channel to inherit the TCP profile used by the control channel.If disabled,the data channel uses FastL4 only.
+*  `inherit_parent_profile` - (Optional) Enables the FTP data channel to inherit the TCP profile used by the control channel.If disabled,the data channel uses FastL4 only.
 
-* `description` - (Optional)User defined description for FTP profile
+* `description` - (Optional) User defined description for FTP profile
 
 

--- a/docs/resources/bigip_ltm_profile_http.md
+++ b/docs/resources/bigip_ltm_profile_http.md
@@ -27,13 +27,13 @@ resource "bigip_ltm_profile_http" "sanjose-http" {
 
 ## Argument Reference
 
-* `name` - (Required,type `string`) Specifies the name of the http profile,name of Profile should be full path. Full path is the combination of the `partition + profile name`,For example `/Common/test-http-profile`.
+* `name` - (Required,type `string`) Specifies the name of the http profile, name of Profile should be full path. Full path is the combination of the `partition + profile name`, for example `/Common/test-http-profile`.
 
-* `proxy_type` - (optional,type `string`) Specifies the proxy mode for this profile: reverse, explicit, or transparent. The default is `reverse`.
+* `proxy_type` - (Optional,type `string`) Specifies the proxy mode for this profile: reverse, explicit, or transparent. The default is `reverse`.
 
-* `defaults_from` - (optional,type `string`) Specifies the profile that you want to use as the parent profile. Your new profile inherits all settings and values from the parent profile specified.
+* `defaults_from` - (Optional,type `string`) Specifies the profile that you want to use as the parent profile. Your new profile inherits all settings and values from the parent profile specified.
 
-* `description` - (optional,type `string`) Specifies user-defined description.
+* `description` - (Optional,type `string`) Specifies user-defined description.
 
 * `basic_auth_realm` - (Optional) Specifies a quoted string for the basic authentication realm. The system sends this string to a client whenever authorization fails. The default value is `none`
 

--- a/docs/resources/bigip_ltm_profile_http.md
+++ b/docs/resources/bigip_ltm_profile_http.md
@@ -27,7 +27,7 @@ resource "bigip_ltm_profile_http" "sanjose-http" {
 
 ## Argument Reference
 
-* `name` (Required,type `string`) Specifies the name of the http profile,name of Profile should be full path. Full path is the combination of the `partition + profile name`,For example `/Common/test-http-profile`.
+* `name` - (Required,type `string`) Specifies the name of the http profile,name of Profile should be full path. Full path is the combination of the `partition + profile name`,For example `/Common/test-http-profile`.
 
 * `proxy_type` - (optional,type `string`) Specifies the proxy mode for this profile: reverse, explicit, or transparent. The default is `reverse`.
 
@@ -45,8 +45,6 @@ resource "bigip_ltm_profile_http" "sanjose-http" {
 
 * `head_insert` - (Optional) Specifies a quoted header string that you want to insert into an HTTP request.Default is `none`.
 
-* `insert_xforwarded_for` - (Optional) When using connection pooling, which allows clients to make use of other client requests' server-side connections, you can insert the X-Forwarded-For header and specify a client IP address
-
 * `response_headers_permitted` - (Optional,type `list`) Specifies headers that the BIG-IP system allows in an HTTP response.If you are specifying more than one header, separate the headers with a blank space.
 
 * `request_chunking` - (Optional,type `string`) Specifies how the system handles HTTP content that is chunked by a client. The default is `preserve`.
@@ -57,17 +55,13 @@ resource "bigip_ltm_profile_http" "sanjose-http" {
 
 * `redirect_rewrite` - (Optional) Specifies whether the system rewrites the URIs that are part of HTTP redirect (3XX) responses. The default is `none`.
 
-* `request_chunking` - (Optional) Specifies how the system handles HTTP content that is chunked by a client. The default is `preserve`.
-
 * `encrypt_cookies` - (Optional) Type the cookie names for the system to encrypt.
 
 * `encrypt_cookie_secret` - (Optional) Type a passphrase for cookie encryption. Note: Since it's a sensitive entity idempotency will fail for it in the update call.
 
-* `insert_xforwarded_for` - (Optional) Specifies, when enabled, that the system inserts an X-Forwarded-For header in an HTTP request with the client IP address, to use with connection pooling. The default is `Disabled`.
+* `insert_xforwarded_for` - (Optional) Specifies, when enabled, that the system inserts an X-Forwarded-For header in an HTTP request with the client IP address, to use with connection pooling. The default is `disabled`.
 
 * `lws_width` - (Optional,type `int`) Specifies the maximum column width for any given line, when inserting an HTTP header in an HTTP request. The default is `80`.
-
-* `lws_width` - (Optional,type `string`) Specifies the linear white space (LWS) separator that the system inserts when a header exceeds the maximum width you specify in the LWS Maximum Columns setting.
 
 * `accept_xff` - (Optional) Enables or disables trusting the client IP address, and statistics from the client IP address, based on the request's XFF (X-forwarded-for) headers, if they exist.
 
@@ -75,9 +69,9 @@ resource "bigip_ltm_profile_http" "sanjose-http" {
 
 * `server_agent_name` - (Optional) Specifies the value of the Server header in responses that the BIG-IP itself generates. The default is BigIP. In order to remove it, "none" string is to be passed. If server_agent_name is commented (or not passed) during the update call, then no changes would be applied and previous value will persist. In order to put default value, we need to pass "BigIP" explicitly.
 
-* `enforcement` -See [Enforcement](#enforcement) below for more details.
+* `enforcement` - (Optional) See [Enforcement](#enforcement) below for more details.
 
-* `http_strict_transport_security` -See [Http_Strict_Transport_Security](#http_strict_transport_security) below for more details.
+* `http_strict_transport_security` - (Optional) See [Http_Strict_Transport_Security](#http_strict_transport_security) below for more details.
 
 ### Enforcement
 

--- a/docs/resources/bigip_ltm_profile_http2.md
+++ b/docs/resources/bigip_ltm_profile_http2.md
@@ -41,7 +41,7 @@ resource "bigip_ltm_profile_http2" "nyhttp2-child" {
 
 ## Argument Reference
 
-* `name` (Required,`type string`) Name of Profile should be full path.The full path is the combination of the `partition + profile name`,For example `/Common/test-http2-profile`.
+* `name` - (Required,`type string`) Name of Profile should be full path. The full path is the combination of the `partition + profile name`, for example `/Common/test-http2-profile`.
 
 * `defaults_from` - (Optional,`type string`) Specifies the profile that you want to use as the parent profile. Your new profile inherits all settings and values from the parent profile specified.
 

--- a/docs/resources/bigip_ltm_profile_httpcompress.md
+++ b/docs/resources/bigip_ltm_profile_httpcompress.md
@@ -29,7 +29,7 @@ resource "bigip_ltm_profile_httpcompress" "sjhttpcompression" {
 
 ## Argument Reference
 
-* `name` (Required,type `string`) Name of the LTM http compress profile,named with their `full path`.The full path is the combination of the `partition + name` (example: `/Common/my-httpcompresprofile` ) or  `partition + directory + name` of the resource  (example: `my-httpcompresprofile`)
+* `name` - (Required,type `string`) Name of the LTM http compress profile, named with their `full path`. The full path is the combination of the `partition + name` (example: `/Common/my-httpcompresprofile` ) or  `partition + directory + name` of the resource  (example: `my-httpcompresprofile`)
 
 * `defaults_from` - (Optional,type `string`) Specifies the profile that you want to use as the parent profile. Your new profile inherits all settings and values from the parent profile specified.
 
@@ -47,7 +47,7 @@ resource "bigip_ltm_profile_httpcompress" "sjhttpcompression" {
 
 * `gzip_memory_level` - (Optional,type `int`) Specifies the number of bytes of memory that the system uses for internal compression buffers when compressing a server response. The default is `8 kilobytes/8192 bytes`.
 
-* `gzip_window_size` - (Optional,type `int`)  Specifies the number of kilobytes in the window size that the system uses when compressing a server response. The default is `16` kilobytes
+* `gzip_window_size` - (Optional,type `int`) Specifies the number of kilobytes in the window size that the system uses when compressing a server response. The default is `16` kilobytes
 
 * `keep_accept_encoding` - (Optional,type `string`) Specifies, when checked (enabled), that the system does not remove the Accept-Encoding: header from an HTTP request. The default is `disabled`.
 

--- a/docs/resources/bigip_ltm_profile_oneconnect.md
+++ b/docs/resources/bigip_ltm_profile_oneconnect.md
@@ -24,7 +24,7 @@ resource "bigip_ltm_profile_oneconnect" "test-oneconnect" {
 
 ## Argument Reference
 
-* `name` (Required,`type string`) Name of Profile should be full path.The full path is the combination of the `partition + profile_name`,For example `/Common/test-oneconnect-profile`.
+* `name` - (Required,`type string`) Name of Profile should be full path.The full path is the combination of the `partition + profile_name`,For example `/Common/test-oneconnect-profile`.
 
 * `partition` - (Optional,`type string`) Displays the administrative partition within which this profile resides
 

--- a/docs/resources/bigip_ltm_profile_server_ssl.md
+++ b/docs/resources/bigip_ltm_profile_server_ssl.md
@@ -28,7 +28,7 @@ resource "bigip_ltm_profile_server_ssl" "test-ServerSsl" {
 
 ## Argument Reference
 
-* `name` (Required,type `string`) Specifies the name of the profile.Name of Profile should be full path,full path is the combination of the `partition + profile name`. For example `/Common/test-serverssl-profile`.
+* `name` - (Required,type `string`) Specifies the name of the profile. Name of Profile should be full path,full path is the combination of the `partition + profile name`. For example `/Common/test-serverssl-profile`.
 
 * `defaults_from` - (Optional) The parent template of this monitor template. Once this value has been set, it cannot be changed. By default, this value is `/Common/serverssl`.
 
@@ -72,18 +72,18 @@ There can be only one SSL profile with this setting enabled.
 
 * `ssl_forward_proxy_bypass` - (Optional) Specifies whether SSL forward proxy bypass feature is enabled or not. The default value is disabled. 
 
-* `ssl_c3d` (Optional) Enables or disables SSL forward proxy bypass on receiving
+* `ssl_c3d` - (Optional) Enables or disables SSL forward proxy bypass on receiving
  handshake_failure, protocol_version or unsupported_extension alert message during the serverside SSL handshake. When enabled and there is an SSL handshake_failure, protocol_version or unsupported_extension alert during the serverside SSL handshake, SSL traffic bypasses the BIG-IP system untouched, without decryption/encryption. The default value is disabled. Conversely, you can specify enabled to use this feature.
 
-* `c3d_ca_cert` (Optional) Specifies the name of the certificate file that is used as the certification authority certificate when SSL client certificate constrained delegation is enabled. The certificate should be generated and installed by you on the system. When selecting this option, type a certificate file name.
+* `c3d_ca_cert` - (Optional) Specifies the name of the certificate file that is used as the certification authority certificate when SSL client certificate constrained delegation is enabled. The certificate should be generated and installed by you on the system. When selecting this option, type a certificate file name.
 
-* `c3d_ca_key` (Optional) Specifies the name of the key file that is used as the certification authority key when SSL client certificate constrained delegation is enabled. The key should be generated and installed by you on the system. When selecting this option, type a key file name.
+* `c3d_ca_key` - (Optional) Specifies the name of the key file that is used as the certification authority key when SSL client certificate constrained delegation is enabled. The key should be generated and installed by you on the system. When selecting this option, type a key file name.
 
-* `c3d-ca-passphrase` (Optional) Specifies the passphrase of the key file that is used as the certification authority key when SSL client certificate constrained delegation is enabled. When selecting this option, type the passphrase corresponding to the selected c3d-ca-key.
+* `c3d-ca-passphrase` - (Optional) Specifies the passphrase of the key file that is used as the certification authority key when SSL client certificate constrained delegation is enabled. When selecting this option, type the passphrase corresponding to the selected c3d-ca-key.
 
-* `c3d-cert-extension-custom-oids` (Optional) Specifies the custom extension OID of the client certificates to be included in the generated certificates using SSL client certificate constrained delegation.
+* `c3d-cert-extension-custom-oids` - (Optional) Specifies the custom extension OID of the client certificates to be included in the generated certificates using SSL client certificate constrained delegation.
 
-* `c3d_cert_extension_includes` (Optional) Specifies the extensions of the client certificates to be included in the generated certificates using SSL client certificate constrained delegation. For example, { basic-constraints }. The default value is { basic-constraints extended-key-usage key-usage subject-alternative-name }. The extensions are:
+* `c3d_cert_extension_includes` - (Optional) Specifies the extensions of the client certificates to be included in the generated certificates using SSL client certificate constrained delegation. For example, { basic-constraints }. The default value is { basic-constraints extended-key-usage key-usage subject-alternative-name }. The extensions are:
 
 	    basic-constraints
 		  Basic constraints are used to indicate whether the certificate belongs

--- a/docs/resources/bigip_ltm_profile_tcp.md
+++ b/docs/resources/bigip_ltm_profile_tcp.md
@@ -29,7 +29,7 @@ resource "bigip_ltm_profile_tcp" "sanjose-tcp-lan-profile" {
 
 ## Argument Reference
 	
-* `name` (Required,type `string`) Name of the LTM TCP Profile,name should be `full path`. The full path is the combination of the `partition + name` (example: /Common/my-pool ) or  `partition + directory + name` of the resource  (example: /Common/test/my-pool )
+* `name` - (Required,type `string`) Name of the LTM TCP Profile,name should be `full path`. The full path is the combination of the `partition + name` (example: /Common/my-pool ) or  `partition + directory + name` of the resource  (example: /Common/test/my-pool )
 
 * `defaults_from` - (Optional,type `string`) Specifies the profile that you want to use as the parent profile. Your new profile inherits all settings and values from the parent profile specified.
 

--- a/docs/resources/bigip_ltm_profile_web_acceleration.md
+++ b/docs/resources/bigip_ltm_profile_web_acceleration.md
@@ -26,11 +26,11 @@ resource "bigip_ltm_profile_web_acceleration" "sample-resource" {
 
 ## Argument Reference
 
-* `name` (Required,type `string`) Specifies the name of the web acceleration profile service ,name of Profile should be full path. Full path is the combination of the `partition + web acceleration profile name`,For example `/Common/sample-resource`.
+* `name` - (Required,type `string`) Specifies the name of the web acceleration profile service ,name of Profile should be full path. Full path is the combination of the `partition + web acceleration profile name`,For example `/Common/sample-resource`.
 
-* `defaults_from` - (optional,type `string`) Specifies the profile that you want to use as the parent profile. Your new profile inherits all settings and values from the parent profile specified.
+* `defaults_from` - (Optional,type `string`) Specifies the profile that you want to use as the parent profile. Your new profile inherits all settings and values from the parent profile specified.
 
-* `cache_size` - (optional,type `int`) 	Specifies the maximum size for the cache. When the cache reaches the maximum size, the system starts removing the oldest entries. The default value is `100 megabytes`.
+* `cache_size` - (Optional,type `int`) 	Specifies the maximum size for the cache. When the cache reaches the maximum size, the system starts removing the oldest entries. The default value is `100 megabytes`.
 
 * `cache_max_entries` - (Optional, type `int`) Specifies the maximum number of entries that can be in the cache. The default value is `0` (zero), which means that the system does not limit the maximum entries.
 

--- a/docs/resources/bigip_ltm_request_log_profile.md
+++ b/docs/resources/bigip_ltm_request_log_profile.md
@@ -29,11 +29,11 @@ resource "bigip_ltm_request_log_profile" "request-log-profile-tc1-child" {
 
 ## Argument Reference
 
-* `name` (Required,type `string`) Name of the Request Logging profile,name of Profile should be full path. Full path is the combination of the `partition + profile name`,For example `/Common/request-log-profile-tc1`.
+* `name` - (Required,type `string`) Name of the Request Logging profile,name of Profile should be full path. Full path is the combination of the `partition + profile name`,For example `/Common/request-log-profile-tc1`.
 
-* `defaults_from` - (optional,type `string`) Specifies the profile from which this profile inherits settings. The default is the system-supplied `request-log` profile.
+* `defaults_from` - (Optional,type `string`) Specifies the profile from which this profile inherits settings. The default is the system-supplied `request-log` profile.
 
-* `description` - (optional,type `string`) Specifies user-defined description.
+* `description` - (Optional,type `string`) Specifies user-defined description.
 
 * `request_logging` - (Optional,type `string`) Enables or disables request logging. The default is `disabled`, possible values are `enabled` and `disabled`.
 

--- a/docs/resources/bigip_ltm_snat.md
+++ b/docs/resources/bigip_ltm_snat.md
@@ -31,7 +31,7 @@ resource "bigip_ltm_snat" "test-snat" {
 
 ## Argument Reference
 
-* `name` - (Required) Name of the SNAT, name of SNAT should be full path. Full path is the combination of the `partition + SNAT name`,For example `/Common/test-snat`.
+* `name` - (Required) Name of the SNAT, name of SNAT should be full path. Full path is the combination of the `partition + SNAT name`, for example `/Common/test-snat`.
 
 * `origins` - (Required) Specifies, for each SNAT that you create, the origin addresses that are to be members of that SNAT. Specify origin addresses by their IP addresses and service ports
 
@@ -41,10 +41,10 @@ resource "bigip_ltm_snat" "test-snat" {
 
 * `mirror` - (Optional) Enables or disables mirroring of SNAT connections.
 
-* `autolasthop` -(Optional) Specifies whether to automatically map last hop for pools or not. The default is to use next level's default.
+* `autolasthop` - (Optional) Specifies whether to automatically map last hop for pools or not. The default is to use next level's default.
 
 * `sourceport` - (Optional) Specifies how the SNAT object handles the client's source port. The default is `preserve`.
 
-* `vlansdisabled` - (Optional,bool) Specifies the VLANs or tunnels for which the SNAT is enabled or disabled. The default is `true`, vlandisabled on VLANS specified by `vlans`,if set to `false` vlanEnabled set on VLANS specified by `vlans` .
+* `vlansdisabled` - (Optional,bool) Specifies the VLANs or tunnels for which the SNAT is enabled or disabled. The default is `true`, vlandisabled on VLANS specified by `vlans`, if set to `false` vlanEnabled set on VLANS specified by `vlans` .
 
 * `vlans` - (Optional) Specifies the available VLANs or tunnels and those for which the SNAT is enabled or disabled.

--- a/docs/resources/bigip_ltm_virtual_server.md
+++ b/docs/resources/bigip_ltm_virtual_server.md
@@ -74,7 +74,7 @@ resource "bigip_ltm_virtual_server" "https" {
 
 * `translate_port` - Enables or disables port translation. Turn port translation off for a virtual server if you want to use the virtual server to load balance connections to any service
 
-* `ip_protocol`- (Optional) Specifies a network protocol name you want the system to use to direct traffic on this virtual server. The default is `tcp`. valid options are [`any`,`udp`,`tcp`]
+* `ip_protocol` - (Optional) Specifies a network protocol name you want the system to use to direct traffic on this virtual server. The default is `tcp`. valid options are [`any`,`udp`,`tcp`]
 
 * `profiles` - (Optional) List of profiles associated both client and server contexts on the virtual server. This includes protocol, ssl, http, etc.
 
@@ -82,7 +82,7 @@ resource "bigip_ltm_virtual_server" "https" {
 
 * `server_profiles` - (Optional) List of server context profiles associated on the virtual server. Not mutually exclusive with profiles and client_profiles
 
-* `source` -  (Optional) Specifies an IP address or network from which the virtual server will accept traffic.
+* `source` - (Optional) Specifies an IP address or network from which the virtual server will accept traffic.
 
 * `irules` - (Optional) The iRules list you want run on this virtual server. iRules help automate the intercepting, processing, and routing of application traffic.
 

--- a/docs/resources/bigip_net_ike_peer.md
+++ b/docs/resources/bigip_net_ike_peer.md
@@ -27,68 +27,68 @@ resource "bigip_net_ike_peer" "example1" {
 
 * `name` - (Required) Name of the ike_peer
 
-* `app_service` - (Optional)The application service that the object belongs to 
+* `app_service` - (Optional) The application service that the object belongs to 
 
-* `ca_cert_file` - (Optional)the trusted root and intermediate certificate authorities 
+* `ca_cert_file` - (Optional) The trusted root and intermediate certificate authorities 
 
-* `crl_file` - (Optional)Specifies the file name of the Certificate Revocation List. Only supported in IKEv1 
+* `crl_file` - (Optional) Specifies the file name of the Certificate Revocation List. Only supported in IKEv1 
 
-* `description` - (Optional)User defined description 
+* `description` - (Optional) User defined description 
 
-* `generate_policy` - (Optional)Enable or disable the generation of Security Policy Database entries(SPD) when the device is the responder of the IKE remote node 
+* `generate_policy` - (Optional) Enable or disable the generation of Security Policy Database entries(SPD) when the device is the responder of the IKE remote node 
 
-* `mode` - (Optional)Defines the exchange mode for phase 1 when racoon is the initiator, or the acceptable exchange mode when racoon is the responder
+* `mode` - (Optional) Defines the exchange mode for phase 1 when racoon is the initiator, or the acceptable exchange mode when racoon is the responder
 
-* `my_cert_file` - (Optional)Specifies the name of the certificate file object
+* `my_cert_file` - (Optional) Specifies the name of the certificate file object
 
-* `my_cert_key_file` - (Optional)Specifies the name of the certificate key file object 
+* `my_cert_key_file` - (Optional) Specifies the name of the certificate key file object 
 
-* `my_cert_key_passphrase` - (Optional)Specifies the passphrase of the key used for my-cert-key-file 
+* `my_cert_key_passphrase` - (Optional) Specifies the passphrase of the key used for my-cert-key-file 
 
-* `my_id_type` - (Optional)Specifies the identifier type sent to the remote host to use in the phase 1 negotiation 
+* `my_id_type` - (Optional) Specifies the identifier type sent to the remote host to use in the phase 1 negotiation 
 
-* `my_id_value` - (Optional)Specifies the identifier value sent to the remote host in the phase 1 negotiation 
+* `my_id_value` - (Optional) Specifies the identifier value sent to the remote host in the phase 1 negotiation 
 
-* `nat_traversal` - (Optional)Enables use of the NAT-Traversal IPsec extension 
+* `nat_traversal` - (Optional) Enables use of the NAT-Traversal IPsec extension 
 
-* `passive` - (Optional)Specifies whether the local IKE agent can be the initiator of the IKE negotiation with this ike-peer
+* `passive` - (Optional) Specifies whether the local IKE agent can be the initiator of the IKE negotiation with this ike-peer
 
-* `peers_cert_file` - (Optional)Specifies the peer’s certificate for authentication 
+* `peers_cert_file` - (Optional) Specifies the peer’s certificate for authentication 
 
-* `peers_cert_type` - (Optional)Specifies that the only peers-cert-type supported is certfile
+* `peers_cert_type` - (Optional) Specifies that the only peers-cert-type supported is certfile
 
-* `peers_id_type` - (Optional)Specifies which of address, fqdn, asn1dn, user-fqdn or keyid-tag types to use as peers-id-type 
+* `peers_id_type` - (Optional) Specifies which of address, fqdn, asn1dn, user-fqdn or keyid-tag types to use as peers-id-type 
 
-* `peers_id_value` - (Optional)Specifies the peer’s identifier to be received 
+* `peers_id_value` - (Optional) Specifies the peer’s identifier to be received 
 
-* `phase1_auth_method` - (Optional)Specifies the authentication method used for phase 1 negotiation 
+* `phase1_auth_method` - (Optional) Specifies the authentication method used for phase 1 negotiation 
 
-* `phase1_encrypt_algorithm` - (Optional)Specifies the encryption algorithm used for the isakmp phase 1 negotiation 
+* `phase1_encrypt_algorithm` - (Optional) Specifies the encryption algorithm used for the isakmp phase 1 negotiation 
 
-* `phase1_hash_algorithm` - (Optional)Defines the hash algorithm used for the isakmp phase 1 negotiation 
+* `phase1_hash_algorithm` - (Optional) Defines the hash algorithm used for the isakmp phase 1 negotiation 
 
-* `phase1_perfect_forward_secrecy` - (Optional)Defines the Diffie-Hellman group for key exchange to provide perfect forward secrecy 
+* `phase1_perfect_forward_secrecy` - (Optional) Defines the Diffie-Hellman group for key exchange to provide perfect forward secrecy 
 
-* `preshared_key` - (Optional)Specifies the preshared key for ISAKMP SAs
+* `preshared_key` - (Optional) Specifies the preshared key for ISAKMP SAs
 
-* `preshared_key_encrypted` - (Optional)Display the encrypted preshared-key for the IKE remote node 
+* `preshared_key_encrypted` - (Optional) Display the encrypted preshared-key for the IKE remote node 
 
 * `prf` - (Optional) Specifies the pseudo-random function used to derive keying material for all cryptographic operations
 
-* `proxy_support` - (Optional)If this value is enabled, both values of ID payloads in the phase 2 exchange are used as the addresses of end-point of IPsec-SAs 
+* `proxy_support` - (Optional) If this value is enabled, both values of ID payloads in the phase 2 exchange are used as the addresses of end-point of IPsec-SAs 
 
-* `remote_address` - (Required)Specifies the IP address of the IKE remote node 
+* `remote_address` - (Required) Specifies the IP address of the IKE remote node 
 
-* `state` - (Optional)Enables or disables this IKE remote node 
+* `state` - (Optional) Enables or disables this IKE remote node 
 
-* `traffic_selector` - (Optional)Specifies the names of the traffic-selector objects associated with this ike-peer 
+* `traffic_selector` - (Optional) Specifies the names of the traffic-selector objects associated with this ike-peer 
 
-* `verify_cert` - (Optional)Specifies whether to verify the certificate chain of the remote peer based on the trusted certificates in ca-cert-file 
+* `verify_cert` - (Optional) Specifies whether to verify the certificate chain of the remote peer based on the trusted certificates in ca-cert-file 
 
-* `version` - (Optional)Specifies which version of IKE to be used 
+* `version` - (Optional) Specifies which version of IKE to be used 
 
-* `dpd_delay` - (Optional)Specifies the number of seconds between Dead Peer Detection messages 
+* `dpd_delay` - (Optional) Specifies the number of seconds between Dead Peer Detection messages 
 
-* `lifetime` - (Optional)Defines the lifetime in minutes of an IKE SA which will be proposed in the phase 1 negotiations 
+* `lifetime` - (Optional) Defines the lifetime in minutes of an IKE SA which will be proposed in the phase 1 negotiations 
 
-* `replay_window_size` - (Optional)Specifies the replay window size of the IPsec SAs negotiated with the IKE remote node 
+* `replay_window_size` - (Optional) Specifies the replay window size of the IPsec SAs negotiated with the IKE remote node 

--- a/docs/resources/bigip_saas_bot_defence_profile.md
+++ b/docs/resources/bigip_saas_bot_defence_profile.md
@@ -30,11 +30,11 @@ resource "bigip_saas_bot_defense_profile" "test-bot-defense" {
 ```
 ## Argument Reference
 
-* `name` (Required,type `string`) Unique name for the Distributed Cloud Services Bot Defense profile. Full path is the combination of the `partition + profile name`,For example `/Common/test-bot-tc1`.
+* `name` - (Required,type `string`) Unique name for the Distributed Cloud Services Bot Defense profile. Full path is the combination of the `partition + profile name`, for example `/Common/test-bot-tc1`.
 
-* `defaults_from` - (optional,type `string`) Distributed Cloud Services Bot Defense parent profile from which this profile will inherit settings. The default is the system-supplied `bd` profile.
+* `defaults_from` - (Optional,type `string`) Distributed Cloud Services Bot Defense parent profile from which this profile will inherit settings. The default is the system-supplied `bd` profile.
 
-* `description` - (optional,type `string`) Specifies descriptive text that identifies the BD profile.
+* `description` - (Optional,type `string`) Specifies descriptive text that identifies the BD profile.
 
 * `application_id` - (Required,type `string`) Specifies the Bot Defense API application ID, enter the value provided by F5 Support
 

--- a/docs/resources/bigip_ssl_key.md
+++ b/docs/resources/bigip_ssl_key.md
@@ -28,7 +28,7 @@ resource "bigip_ssl_key" "test-key" {
 ## Argument Reference
 
 
-* `name`- (Required,type `string`) Name of the SSL Certificate key to be Imported on to BIGIP
+* `name` - (Required,type `string`) Name of the SSL Certificate key to be Imported on to BIGIP
 
 * `content` - (Required) Content of certificate key on Local Disk,path of SSL certificate key will be provided to terraform `file` function 
 

--- a/docs/resources/bigip_sys_dns.md
+++ b/docs/resources/bigip_sys_dns.md
@@ -22,10 +22,10 @@ resource "bigip_sys_dns" "dns1" {
 
 ## Argument Reference
 
-* `description`- (Required,type `string` )Provide description for your DNS server
+* `description` - (Required,type `string`) Provide description for your DNS server
 
-* `name_servers` - (Required,type `list` ) Specifies the name servers that the system uses to validate DNS lookups, and resolve host names.
+* `name_servers` - (Required,type `list`) Specifies the name servers that the system uses to validate DNS lookups, and resolve host names.
 
-* `number_of_dots` - (Optional,type `int` ) Configures the number of dots needed in a name before an initial absolute query will be made.
+* `number_of_dots` - (Optional,type `int`) Configures the number of dots needed in a name before an initial absolute query will be made.
 
-* `search` - (Optional,type `list` ) Specifies the domains that the system searches for local domain lookups, to resolve local host names.
+* `search` - (Optional,type `list`) Specifies the domains that the system searches for local domain lookups, to resolve local host names.

--- a/docs/resources/bigip_sys_iapp.md
+++ b/docs/resources/bigip_sys_iapp.md
@@ -24,9 +24,9 @@ resource "bigip_sys_iapp" "simplehttp" {
 
 * `name` - (Required, type `string`) Name of the iApp.
 * `jsonfile` - (Required, type `string`) Refer to the Json file which will be deployed on F5 BIG-IP.
-* `description` - (Optional type `string`) - User defined description.
-* `partition` - (Optional type `string`) - Displays the administrative partition within which the application resides.
-* `execute_action` - (Optional type `string`) - Run the specified template action associated with the application, this option can be specified in `json` with `executeAction`, value specified with `execute_action` attribute take precedence over `json` value
+* `description` - (Optional type `string`) User defined description.
+* `partition` - (Optional type `string`) Displays the administrative partition within which the application resides.
+* `execute_action` - (Optional type `string`) Run the specified template action associated with the application, this option can be specified in `json` with `executeAction`, value specified with `execute_action` attribute take precedence over `json` value
 
 ## Example Usage of Json file
 ```json

--- a/docs/resources/bigip_sys_snmp.md
+++ b/docs/resources/bigip_sys_snmp.md
@@ -24,7 +24,7 @@ resource "bigip_sys_snmp" "snmp" {
 
 ## Argument Reference
 
-* `sys_contact` -  (Optional) Specifies the contact information for the system administrator.
+* `sys_contact` - (Optional) Specifies the contact information for the system administrator.
 
 * `sys_location` - Describes the system's physical location.
 

--- a/docs/resources/bigip_sys_snmp_traps.md
+++ b/docs/resources/bigip_sys_snmp_traps.md
@@ -25,7 +25,7 @@ resource "bigip_sys_snmp_traps" "snmp_traps" {
 
 ## Argument Reference
 
-* `name` -  (Optional) Name of the snmp trap.
+* `name` - (Optional) Name of the snmp trap.
 
 * `community` - (Optional) Specifies the community string used for this trap.
 

--- a/docs/resources/bigip_traffic_selector.md
+++ b/docs/resources/bigip_traffic_selector.md
@@ -25,7 +25,7 @@ resource bigip_traffic_selector "test-selector" {
 
 ## Argument Reference
 
-* `name` - (Required) Name of the IPSec traffic-selector,it should be "full path".The full path is the combination of the partition + name of the IPSec traffic-selector.(For example `/Common/test-selector`)
+* `name` - (Required) Name of the IPSec traffic-selector, it should be "full path". The full path is the combination of the partition + name of the IPSec traffic-selector (For example `/Common/test-selector`).
 
 * `description` - (Optional,type `string`) Description of the traffic selector.
 

--- a/docs/resources/bigip_vcmp_guest.md
+++ b/docs/resources/bigip_vcmp_guest.md
@@ -40,7 +40,7 @@ resource "bigip_vcmp_guest" "vcmp-test" {
 
 * `initial_hotfix` - (Optional, `string`) Specifies the hotfix ISO image file which is applied on top of the base image.
 
-* `vlans` - (Optional, `list`) Specifies the list of VLANs the vCMP guest uses to communicate with other guests, the host, and with the external network. The naming format must be the combination of the partition + name. For example /Common/my-vlan
+* `vlans` - (Optional, `list`) Specifies the list of VLANs the vCMP guest uses to communicate with other guests, the host, and with the external network. The naming format must be the combination of the partition + name (For example `/Common/my-vlan`).
 
 * `mgmt_network` - (Optional, `string`) Specifies the method by which the management address is used in the vCMP guest. options : [`bridged`,`isolated`,`host-only`].
 

--- a/docs/resources/bigip_waf_policy.md
+++ b/docs/resources/bigip_waf_policy.md
@@ -131,28 +131,28 @@ The `defense_attributes` block supports the following:
 ### file types
 The `file_types` block supports the following:
 
-* `name` - (Optional , `string`) Specifies the file type name as appearing in the URL extension.
+* `name` - (Optional, `string`) Specifies the file type name as appearing in the URL extension.
 
-* `type` - (Optional , `string`) Determines the type of the name attribute. Only when setting the type to `wildcard` will the special wildcard characters in the name be interpreted as such
+* `type` - (Optional, `string`) Determines the type of the name attribute. Only when setting the type to `wildcard` will the special wildcard characters in the name be interpreted as such
 
-* `allowed` - (Optional , `bool`) Determines whether the file type is allowed or disallowed. In either of these cases the VIOL_FILETYPE violation is issued (if enabled) for an incoming request- 
+* `allowed` - (Optional, `bool`) Determines whether the file type is allowed or disallowed. In either of these cases the VIOL_FILETYPE violation is issued (if enabled) for an incoming request- 
   * No allowed file type matched the file type of the request.
   * The file type of the request matched a disallowed file type.
 
 ### IP Exceptions
 The `ip_exceptions` block supports the following:
 
-* `ip_address` - (Required , `string`) Specifies the IP address that you want the system to trust.
+* `ip_address` - (Required, `string`) Specifies the IP address that you want the system to trust.
 
-* `ip_mask` - (optional , `string`) Specifies the netmask of the exceptional IP address. This is an optional field.
+* `ip_mask` - (optional, `string`) Specifies the netmask of the exceptional IP address. This is an optional field.
 
-* `block_requests` - (Optional , `string`) Specifies how the system responds to blocking requests sent from this IP address. Possible options [`always`, `never`, `policy-default`].
+* `block_requests` - (Optional, `string`) Specifies how the system responds to blocking requests sent from this IP address. Possible options [`always`, `never`, `policy-default`].
 
-* `trustedby_policybuilder` - (Optional , `bool`) Specifies when enabled the Policy Builder considers traffic from this IP address as being safe.
+* `trustedby_policybuilder` - (Optional, `bool`) Specifies when enabled the Policy Builder considers traffic from this IP address as being safe.
 
-* `ignore_anomalies` - (Optional , `bool`) Specifies when enabled that the system considers this IP address legitimate and does not take it into account when performing brute force prevention.
+* `ignore_anomalies` - (Optional, `bool`) Specifies when enabled that the system considers this IP address legitimate and does not take it into account when performing brute force prevention.
 
-* `ignore_ipreputation` - (Optional , `bool`) Specifies when enabled that the system considers this IP address legitimate even if it is found in the IP Intelligence database (a database of questionable IP addresses).
+* `ignore_ipreputation` - (Optional, `bool`) Specifies when enabled that the system considers this IP address legitimate even if it is found in the IP Intelligence database (a database of questionable IP addresses).
 
 ## Attributes Reference
 


### PR DESCRIPTION
Changes to capitalization and punctuation for most docs. 
Example: `name (required)` becomes `name - (Required)`

Remove duplicate settings from http profile (request_chunking and insert_xforwarded_for)

A few files referenced the wrong in the `default's from` setting. This has been fixed.