### PR TITLE
Default Persistence Profile

### DIFF
--- a/bigip/resource_bigip_ltm_virtual_server.go
+++ b/bigip/resource_bigip_ltm_virtual_server.go
@@ -432,10 +432,8 @@ func resourceBigipLtmVirtualServerRead(ctx context.Context, d *schema.ResourceDa
 		FullProfileName := "/" + profile.Partition + "/" + profile.Name
 		profileNames.Add(FullProfileName)
 	}
-	if profileNames.Len() > 0 {
-		_ = d.Set("persistence_profiles", profileNames)
-	}
 
+	_ = d.Set("persistence_profiles", profileNames)
 	_ = d.Set("fallback_persistence_profile", vs.FallbackPersistenceProfile)
 	_ = d.Set("source_port", vs.SourcePort)
 	_ = d.Set("vlans_enabled", vs.VlansEnabled)

--- a/bigip/resource_bigip_ltm_virtual_server_test.go
+++ b/bigip/resource_bigip_ltm_virtual_server_test.go
@@ -7,7 +7,13 @@ If a copy of the MPL was not distributed with this file,You can obtain one at ht
 package bigip
 
 import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
 	"fmt"
+	"io"
+	"log"
+	"net/http"
 	"testing"
 
 	bigip "github.com/f5devcentral/go-bigip"
@@ -871,4 +877,119 @@ resource "bigip_ltm_virtual_server" "server736-b" {
   mask        = "19"
 }
 `, vsName1, vsName2)
+}
+
+func TestAccBigipLtmVirtualServer_PersistProfileDeletion(t *testing.T) {
+	vsName := "test-vs-persist"
+	partition := "Common"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers: testAccProviders,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testCheckVSsDestroyed,
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: testVSCreateWithPersistence(vsName),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckVSExists(vsName),
+					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "name", "/Common/"+vsName),
+					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "destination", "192.168.50.2"),
+					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "ip_protocol", "tcp"),
+					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "persist.0.name", "cookie"),
+				),
+			},
+			{
+				PreConfig: func() {
+					testAccBigipLtmVSPersistentProfilesDelete(t, vsName, partition)
+				},
+				Config: testVSWithoutPersistence(vsName),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckVSExists(vsName),
+					resource.TestCheckNoResourceAttr("bigip_ltm_virtual_server.test-vs", "persist.0.name"),
+				),
+			},
+		},
+	})
+}
+
+func testVSWithoutPersistence(name string) string {
+	return fmt.Sprintf(`
+resource "bigip_ltm_virtual_server" "test-vs" {
+  name        = "/Common/%s"
+  destination = "192.168.50.2"
+  ip_protocol = "tcp"
+  port        = 80
+  profiles    = ["/Common/http"]
+}
+`, name)
+}
+
+func testVSCreateWithPersistence(name string) string {
+	return fmt.Sprintf(`
+resource "bigip_ltm_virtual_server" "test-vs" {
+  name        = "/Common/%s"
+  destination = "192.168.50.2"
+  ip_protocol = "tcp"
+  port        = 80
+  profiles    = ["/Common/http"]
+  persist {
+    name = "cookie"
+  }
+}
+`, name)
+}
+
+func testAccBigipLtmVSPersistentProfilesDelete(t *testing.T, vsName string, partition string) {
+	clientBigip := testAccProvider.Meta().(*bigip.BigIP)
+
+	// Build the URL for PATCH
+	uri := fmt.Sprintf("%s/mgmt/tm/ltm/virtual/~%s~%s", clientBigip.Host, partition, vsName)
+
+	// Define the request body
+	payload := map[string]interface{}{
+		"kind":      "tm:ltm:virtual:virtualstate",
+		"name":      vsName,
+		"partition": partition,
+		"fullPath":  fmt.Sprintf("/%s/%s", partition, vsName),
+		"persist":   []interface{}{},
+	}
+
+	bodyBytes, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("[ERROR] Failed to marshal JSON body: %v", err)
+	}
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: tr}
+
+	req, err := http.NewRequest("PATCH", uri, bytes.NewBuffer(bodyBytes))
+	if err != nil {
+		t.Fatalf("[ERROR] Failed to create PATCH request: %v", err)
+	}
+
+	req.SetBasicAuth(clientBigip.User, clientBigip.Password)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("[ERROR] HTTP request failed: %v", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("[DEBUG] Could not close response body from %s", uri)
+		}
+	}()
+
+	if resp.StatusCode != 200 {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("[ERROR] Failed to patch virtual server. Status: %s, Body: %s", resp.Status, string(respBody))
+	}
+
 }


### PR DESCRIPTION
Issue: Default Persistence Profile #1062 
Fix: This change ensures that the persistence_profiles attribute is always updated in the Terraform state, even when empty.


Test cases description:

go test -run TestAccBigipLtmVirtualServer_PersistProfileDeletion -mod=mod
PASS
ok  	github.com/F5Networks/terraform-provider-bigip/bigip	0.572s
