### PR TITLE
fix: prevent index out of range panics from `SplitNodePort`

### DIFF
--- a/bigip/resource_bigip_ltm_pool_attachment.go
+++ b/bigip/resource_bigip_ltm_pool_attachment.go
@@ -444,6 +444,6 @@ func SplitNodePort(s string) []string {
 	case m < n:
 		return strings.Split(s, ".")
 	default:
-		return nil
+		return []string{s}
 	}
 }


### PR DESCRIPTION
This makes `SplitNodePort` behave like `strings.Split` (as the code paths expects at least one element) and prevents index out of range panics (which crashes the terraform plugin on applies). 

The CLA has been signed and emailed.