### PR TITLE
Added the support for deletion of app from a tenant

### DIFF
--- a/bigip/resource_bigip_as3.go
+++ b/bigip/resource_bigip_as3.go
@@ -16,6 +16,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"time"
 
 	bigip "github.com/f5devcentral/go-bigip"
 	"github.com/f5devcentral/go-bigip/f5teem"
@@ -188,6 +189,29 @@ func resourceBigipAs3() *schema.Resource {
 				Computed:    true,
 				Description: "Will define Perapp mode enabled on BIG-IP or not",
 			},
+			"delete_apps": {
+				Type:        schema.TypeList,
+				MaxItems:    1,    // Ensures only one delete_apps block is allowed
+				Optional:    true, // The block is optional in the configuration
+				Description: "Block for specifying tenant name and apps to delete.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"tenant_name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The name of the tenant for application deletion.",
+						},
+						"apps": {
+							Type:        schema.TypeList,
+							Required:    true,
+							Description: "List of applications to delete from the specified tenant.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -292,6 +316,21 @@ func resourceBigipAs3Create(ctx context.Context, d *schema.ResourceData, meta in
 	defer m.Unlock()
 	as3Json := d.Get("as3_json").(string)
 	tenantFilter := d.Get("tenant_filter").(string)
+	deleteAppsBlocks := d.Get("delete_apps").([]interface{})
+
+	// Check if delete_apps is set, call the delete_apps handler
+	// can you please properly fix the below code with proper logging?
+	// saying the delete_apps and as3_json is mutual exclusive
+
+	if len(deleteAppsBlocks) > 0 && len(as3Json) > 0 {
+		return diag.FromErr(fmt.Errorf("'delete_apps' and 'as3_json' are mutually exclusive. Please use only one of these attributes"))
+	}
+
+	if len(deleteAppsBlocks) > 0 {
+		log.Printf("[INFO] Detected delete_apps block. Redirecting to deletion logic.")
+		return handleDeleteApps(ctx, d, client)
+	}
+
 	var tenantCount []string
 	perApplication, err := client.CheckSetting()
 	if err != nil {
@@ -473,6 +512,17 @@ func resourceBigipAs3Update(ctx context.Context, d *schema.ResourceData, meta in
 	m.Lock()
 	defer m.Unlock()
 	as3Json := d.Get("as3_json").(string)
+	deleteAppsBlocks := d.Get("delete_apps").([]interface{})
+
+	if len(deleteAppsBlocks) > 0 && len(as3Json) > 0 {
+		return diag.FromErr(fmt.Errorf("'delete_apps' and 'as3_json' are mutually exclusive. Please use only one of these attributes"))
+	}
+
+	// Handle specific application deletions if delete_apps is set
+	if len(deleteAppsBlocks) > 0 {
+		log.Printf("[INFO] Detected delete_apps block. Redirecting to deletion-specific logic.")
+		return handleDeleteApps(ctx, d, client)
+	}
 	log.Printf("[INFO] Updating As3 Config :%s", as3Json)
 	oldApplicationList := d.Get("application_list").(string)
 	tenantList, _, applicationList := client.GetTenantList(as3Json)
@@ -581,6 +631,18 @@ func resourceBigipAs3Delete(ctx context.Context, d *schema.ResourceData, meta in
 	defer m.Unlock()
 	var name string
 	var tList string
+	as3Json := d.Get("as3_json").(string)
+	deleteAppsBlocks := d.Get("delete_apps").([]interface{})
+
+	if len(deleteAppsBlocks) > 0 && len(as3Json) > 0 {
+		return diag.FromErr(fmt.Errorf("'delete_apps' and 'as3_json' are mutually exclusive. Please use only one of these attributes"))
+	}
+
+	// Handle specific application deletions if delete_apps is set
+	if len(deleteAppsBlocks) > 0 {
+		log.Printf("[INFO] Detected delete_apps block. Redirecting to deletion-specific logic.")
+		return handleDeleteApps(ctx, d, client)
+	}
 
 	if c_attr, c_ok := d.GetOk("controls"); c_ok {
 		controls := c_attr.(map[string]interface{})
@@ -591,7 +653,7 @@ func resourceBigipAs3Delete(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if d.Get("as3_json") != nil {
-		tList, _, _ = client.GetTenantList(d.Get("as3_json").(string))
+		tList, _, _ = client.GetTenantList(as3Json)
 	}
 
 	if d.Id() != "" && tList != "" && d.Get("tenant_filter") == "" {
@@ -652,4 +714,42 @@ func GenerateRandomString(length int) (string, error) {
 		randomString[i] = charset[randomIndex.Int64()]
 	}
 	return string(randomString), nil
+}
+
+func handleDeleteApps(ctx context.Context, d *schema.ResourceData, client *bigip.BigIP) diag.Diagnostics {
+	deleteAppsBlocks := d.Get("delete_apps").([]interface{})
+	tenantName := d.Get("tenant_name").(string)
+
+	for _, block := range deleteAppsBlocks {
+		blockData := block.(map[string]interface{})
+		tenant := blockData["tenant_name"].(string)
+		appsToDeleteRaw := blockData["apps"].([]interface{})
+		var appsToDelete []string
+		for _, app := range appsToDeleteRaw {
+			appsToDelete = append(appsToDelete, app.(string))
+		}
+
+		log.Printf("[INFO] Deleting applications %v under tenant '%s'", appsToDelete, tenant)
+
+		// Check if tenant exists
+		as3Resp, err := client.GetAs3(tenant, "", false)
+		if err != nil || len(as3Resp) == 0 {
+			log.Printf("[WARN] Skipping deletion: Tenant '%s' not found or empty: %v", tenant, err)
+			continue // Do not fail – just skip this block
+		}
+
+		for _, app := range appsToDelete {
+			log.Printf("[INFO] Attempting to delete application '%s' in tenant '%s'", app, tenant)
+
+			err := client.DeletePerApplicationAs3Bigip(tenant, app)
+			if err != nil {
+				log.Printf("[ERROR] Failed to delete application '%s' in tenant '%s': %v", app, tenant, err)
+				return diag.FromErr(fmt.Errorf("failed to delete app '%s': %v", app, err))
+			}
+			log.Printf("[INFO] Successfully deleted application '%s' in tenant '%s'", app, tenant)
+		}
+	}
+	d.SetId(fmt.Sprintf("deleted-%s-%d", tenantName, time.Now().Unix()))
+
+	return nil
 }

--- a/docs/resources/bigip_as3.md
+++ b/docs/resources/bigip_as3.md
@@ -534,13 +534,13 @@ description: |-
 
 The `bigip_as3` resource allows you to **post full AS3 declarations** or **selectively delete one or more applications** from a specific tenant in BIG-IP.
 
-> ⚠️ **Note**: `delete_apps` and `as3_json` are **mutually exclusive**. You must use only one of them in a single `bigip_as3` resource block.
+> **Note**: `delete_apps` and `as3_json` are **mutually exclusive**. You must use only one of them in a single `bigip_as3` resource block.
 
 ---
 
 ## Example Usage
 
-### 🔁 Delete Specific Applications from a Tenant
+### Delete Specific Applications from a Tenant
 
 ```hcl
 resource "bigip_as3" "as3_app_deletion" {
@@ -554,7 +554,7 @@ resource "bigip_as3" "as3_app_deletion" {
 }
 ```
 
-### 📤 Post a Full AS3 Declaration
+### Post a Full AS3 Declaration
 
 ```hcl
 resource "bigip_as3" "as3_declare" {
@@ -566,7 +566,7 @@ resource "bigip_as3" "as3_declare" {
 
 ## Argument Reference
 
-### 🧱 Common Attributes
+### Common Attributes
 
 - `ignore_metadata` - (Optional, Default: false) Set to true to ignore AS3 metadata when comparing.
 - `tenant_filter` - (Optional) Filters tenants from AS3 declaration.
@@ -577,14 +577,14 @@ resource "bigip_as3" "as3_declare" {
 
 ---
 
-### 📦 delete_apps Block
+### delete_apps Block
 
 Block for deleting specific applications from a BIG-IP tenant.
 
 - `tenant_name` - (Required) Name of the tenant containing the apps to delete.
 - `apps` - (Required) List of application names to delete from the specified tenant.
 
-> ⚠️ `delete_apps` cannot be used together with `as3_json`.
+> `delete_apps` cannot be used together with `as3_json`.
 
 #### Example
 
@@ -597,7 +597,7 @@ delete_apps {
 
 ---
 
-## ⚙️ Behavior
+## Behavior
 
 When `delete_apps` is used, Terraform logs “Creating...”, but the underlying logic performs application deletion via REST API calls.
 
@@ -621,6 +621,6 @@ A synthetic resource ID is assigned to keep Terraform state consistent after suc
 
 ## Import
 
-⚠️ This resource does not support importing existing AS3 declarations or partial app deletion states.
+This resource does not support importing existing AS3 declarations or partial app deletion states.
 
 * `AS3 documentation` - https://clouddocs.f5.com/products/extensions/f5-appsvcs-extension/latest/userguide/composing-a-declaration.html

--- a/docs/resources/bigip_as3.md
+++ b/docs/resources/bigip_as3.md
@@ -522,7 +522,7 @@ resource "bigip_as3" "test" {
 ```
 
 
-# bigip_as3
+# bigip_as3 delete one or more applications
 
 The `bigip_as3` resource allows you to **post full AS3 declarations** or **selectively delete one or more applications** from a specific tenant in BIG-IP.
 

--- a/docs/resources/bigip_as3.md
+++ b/docs/resources/bigip_as3.md
@@ -522,14 +522,6 @@ resource "bigip_as3" "test" {
 ```
 
 
----
-layout: "bigip"
-page_title: "BIG-IP: bigip_as3"
-subcategory: "AS3"
-description: |-
-  Provides support for posting AS3 declarations or deleting specific applications from a tenant using BIG-IP AS3.
----
-
 # bigip_as3
 
 The `bigip_as3` resource allows you to **post full AS3 declarations** or **selectively delete one or more applications** from a specific tenant in BIG-IP.

--- a/docs/resources/bigip_as3.md
+++ b/docs/resources/bigip_as3.md
@@ -521,4 +521,106 @@ resource "bigip_as3" "test" {
 
 ```
 
+
+---
+layout: "bigip"
+page_title: "BIG-IP: bigip_as3"
+subcategory: "AS3"
+description: |-
+  Provides support for posting AS3 declarations or deleting specific applications from a tenant using BIG-IP AS3.
+---
+
+# bigip_as3
+
+The `bigip_as3` resource allows you to **post full AS3 declarations** or **selectively delete one or more applications** from a specific tenant in BIG-IP.
+
+> ⚠️ **Note**: `delete_apps` and `as3_json` are **mutually exclusive**. You must use only one of them in a single `bigip_as3` resource block.
+
+---
+
+## Example Usage
+
+### 🔁 Delete Specific Applications from a Tenant
+
+```hcl
+resource "bigip_as3" "as3_app_deletion" {
+  delete_apps {
+    tenant_name = "Tenant-2"
+    apps        = [
+      "terraform_vs_http",
+      "legacy_app"
+    ]
+  }
+}
+```
+
+### 📤 Post a Full AS3 Declaration
+
+```hcl
+resource "bigip_as3" "as3_declare" {
+  as3_json = file("${path.module}/as3_payload.json")
+}
+```
+
+---
+
+## Argument Reference
+
+### 🧱 Common Attributes
+
+- `ignore_metadata` - (Optional, Default: false) Set to true to ignore AS3 metadata when comparing.
+- `tenant_filter` - (Optional) Filters tenants from AS3 declaration.
+- `tenant_name` - (Computed) The tenant name used.
+- `per_app_mode` - (Computed) Whether the AS3 was posted in per-app mode.
+- `task_id` - (Computed) The ID of the task created in BIG-IP when AS3 was posted.
+- `application_list` - (Computed) List of applications that were managed.
+
+---
+
+### 📦 delete_apps Block
+
+Block for deleting specific applications from a BIG-IP tenant.
+
+- `tenant_name` - (Required) Name of the tenant containing the apps to delete.
+- `apps` - (Required) List of application names to delete from the specified tenant.
+
+> ⚠️ `delete_apps` cannot be used together with `as3_json`.
+
+#### Example
+
+```hcl
+delete_apps {
+  tenant_name = "Tenant-2"
+  apps        = ["terraform_vs_http"]
+}
+```
+
+---
+
+## ⚙️ Behavior
+
+When `delete_apps` is used, Terraform logs “Creating...”, but the underlying logic performs application deletion via REST API calls.
+
+Each app in the `apps` list is deleted using:
+
+```
+DELETE /mgmt/shared/appsvcs/declare/{tenant}/applications/{app}
+```
+
+A synthetic resource ID is assigned to keep Terraform state consistent after successful deletion.
+
+---
+
+## Outputs
+
+- `task_id` – AS3 task ID used in BIG-IP.
+- `application_list` – List of deleted applications (if applicable).
+- `tenant_list` – List of affected tenants.
+
+---
+
+## Import
+
+⚠️ This resource does not support importing existing AS3 declarations or partial app deletion states.
+
 * `AS3 documentation` - https://clouddocs.f5.com/products/extensions/f5-appsvcs-extension/latest/userguide/composing-a-declaration.html


### PR DESCRIPTION
Add delete_apps Support to bigip_as3 Resource

1. New delete_apps Block
Allows users to declaratively delete specific applications from a tenant.

Example usage:

```
resource "bigip_as3" "as3_app_deletion" {
  delete_apps {
    tenant_name = "tenant"
    apps        = ["A1", "A2"]
  }
}
```



Dummy ID Handling to Avoid Inconsistent State
After deletion, we assign a synthetic resource ID to prevent Terraform errors 
This ensures the resource remains in state and prevents apply-time inconsistencies.