### PR TITLE
Docs fix for resource bigip_ltm_node

### DIFF
--- a/docs/resources/bigip_ltm_node.md
+++ b/docs/resources/bigip_ltm_node.md
@@ -50,6 +50,8 @@ resource "bigip_ltm_node" "node" {
 
 * `state` - (Optional) Default is "user-up" you can set to "user-down" if you want to disable
 
+* `session` - (Optional) Enables or disables the node for new sessions. Can be set to `user-enabled` or `user-disabled`. (Default: `user-enabled`).
+
  ~> *NOTE* Below attributes needs to be configured under fqdn option.
 
 * `interval` - (Optional, type `string`) Specifies the amount of time before sending the next DNS query. Default is 3600. This needs to be specified inside the fqdn (fully qualified domain name).

--- a/docs/resources/bigip_ltm_node.md
+++ b/docs/resources/bigip_ltm_node.md
@@ -52,11 +52,17 @@ resource "bigip_ltm_node" "node" {
 
 * `session` - (Optional) Enables or disables the node for new sessions. Can be set to `user-enabled` or `user-disabled`. (Default: `user-enabled`).
 
- ~> *NOTE* Below attributes needs to be configured under fqdn option.
+### fqdn(fully qualified domain name) Configuration Block
 
-* `interval` - (Optional, type `string`) Specifies the amount of time before sending the next DNS query. Default is 3600. This needs to be specified inside the fqdn (fully qualified domain name).
+* `name` - (Optional, type `string`) The fully qualified domain name of the node. Cannot configure with the `address` argument.
 
-* `address_family` - (Optional) Specifies the node's address family. The default is 'unspecified', or IP-agnostic. This needs to be specified inside the fqdn (fully qualified domain name).
+* `interval` - (Optional, type `string`) Specifies the amount of time before sending the next DNS query. (Default: `3600`)
+
+* `address_family` - (Optional, type `string`) Specifies the node's address family. Can be `all`, `ipv4` or `ipv6` (Default: `ipv4`)
+
+* `autopopulate` - (Optional, type `string`) Specifies if the node should scale to the IP address set returned by DNS. (Default: `disabled`)
+
+* `downinterval` - (Optional, type `int`) The number of attempts to resolve a domain name. (Default: `5`)
 
 ## Importing
 An existing Node can be imported into this resource by supplying Node Name in `full path` as `id`.


### PR DESCRIPTION
This PR significantly enhances the documentation for the bigip_ltm_node resource.

Key updates include:
- Documentation for the session attribute has been added.
- The section for FQDN (fully qualified domain name) has been improved by creating a dedicated fqdn configuration block.
- The following arguments for the fqdn block are now documented:
    - name
    - interval
    - address_family
    - autopopulate
    - downinterval

These changes provide clearer and more comprehensive guidance for users configuring nodes, especially those using FQDN. 