### PR TITLE
Fix formatting of subcategory in bigip_ltm_ifile.md

### DIFF
--- a/docs/resources/bigip_ltm_ifile.md
+++ b/docs/resources/bigip_ltm_ifile.md
@@ -1,7 +1,7 @@
 ---
 layout: "bigip"
 page_title: "BIG-IP: bigip_ltm_ifile"
-subcategory: "Local Traffic Manager (LTM)"
+subcategory: "Local Traffic Manager(LTM)"
 description: |-
   Provides details about bigip_ltm_ifile resource
 ---


### PR DESCRIPTION
This resource is split out from the other bigip_ltm items due to inconsisent spacing in the subcategory