### PR TITLE
fix: fix refresh state errors by dropping nodes that go missing

### DIFF
--- a/bigip/resource_bigip_ltm_node.go
+++ b/bigip/resource_bigip_ltm_node.go
@@ -197,14 +197,14 @@ func resourceBigipLtmNodeRead(ctx context.Context, d *schema.ResourceData, meta 
 	log.Println("[INFO] Fetching node " + name)
 
 	node, err := client.GetNode(name)
-	if err != nil {
-		log.Printf("[ERROR] Unable to retrieve node %s  %v :", name, err)
-		return diag.FromErr(err)
-	}
 	if node == nil {
 		log.Printf("[WARN] Node (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		log.Printf("[ERROR] Unable to retrieve node %s  %v :", name, err)
+		return diag.FromErr(err)
 	}
 	if node.FQDN.Name != "" {
 		_ = d.Set("address", node.FQDN.Name)

--- a/bigip/resource_bigip_ltm_node_test.go
+++ b/bigip/resource_bigip_ltm_node_test.go
@@ -8,6 +8,7 @@ package bigip
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	bigip "github.com/f5devcentral/go-bigip"
@@ -289,6 +290,9 @@ func testCheckNodesDestroyed(s *terraform.State) error {
 		name := rs.Primary.ID
 		node, err := client.GetNode(name)
 		if err != nil {
+			if strings.Contains(err.Error(), "not found") {
+				return nil
+			}
 			return err
 		}
 		if node != nil {


### PR DESCRIPTION
Related-to: https://github.com/F5Networks/terraform-provider-bigip/issues/1139

An example fix for one of the broken resources. This issue exists in **most if not all** resources in the provider!!!!