### PR TITLE
adding monitor resources fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,7 +34,7 @@ run:
   #
   # Allowed values: readonly|vendor|mod
   # Default: ""
-  modules-download-mode: readonly
+  modules-download-mode: vendor
   # Allow multiple parallel golangci-lint instances running.
   # If false, golangci-lint acquires file lock on start.
   # Default: false

--- a/bigip/provider.go
+++ b/bigip/provider.go
@@ -201,6 +201,11 @@ func Provider() *schema.Provider {
 			"bigip_gtm_pool":                        resourceBigipGtmPool(),
 			"bigip_gtm_datacenter":                  resourceBigipGtmDatacenter(),
 			"bigip_gtm_server":                      resourceBigipGtmServer(),
+			"bigip_gtm_monitor_http":                resourceBigipGtmMonitorHttp(),
+			"bigip_gtm_monitor_https":               resourceBigipGtmMonitorHttps(),
+			"bigip_gtm_monitor_tcp":                 resourceBigipGtmMonitorTcp(),
+			"bigip_gtm_monitor_postgresql":          resourceBigipGtmMonitorPostgresql(),
+			"bigip_gtm_monitor_bigip":               resourceBigipGtmMonitorBigip(),
 		},
 	}
 	p.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {

--- a/bigip/resource_bigip_gtm_monitor_bigip.go
+++ b/bigip/resource_bigip_gtm_monitor_bigip.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2019 F5 Networks Inc.
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+package bigip
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	bigip "github.com/f5devcentral/go-bigip"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// normalizeGtmBigipDestination ensures the destination is in a consistent format
+// for the BIG-IP "bigip" monitor type. The API returns destination as "*:*" by default.
+// This function normalizes various input formats to a consistent "address:port" format.
+func normalizeGtmBigipDestination(destination string) string {
+	if destination == "" {
+		return "*:*"
+	}
+	// If destination doesn't contain a colon, it's just an address - add wildcard port
+	if !strings.Contains(destination, ":") {
+		return destination + ":*"
+	}
+	return destination
+}
+
+// validateGtmBigipDestination validates that the destination follows BIG-IP API rules:
+// - "*:*" is valid (all wildcards)
+// - "*:port" is valid (wildcard IP + specific port)
+// - "ip:port" is valid (specific IP + specific port)
+// - "ip:*" is INVALID (specific IP + wildcard port) - BIG-IP requires a port when an address is specified
+func validateGtmBigipDestination(destination string) error {
+	if destination == "" || destination == "*:*" {
+		return nil
+	}
+	parts := strings.SplitN(destination, ":", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid destination format %q: must be in 'address:port' format", destination)
+	}
+	address := parts[0]
+	port := parts[1]
+	// If a specific IP address is provided (not wildcard), a specific port is required
+	if address != "*" && port == "*" {
+		return fmt.Errorf("invalid destination %q: when a specific IP address is provided, a specific port is required (BIG-IP API constraint). Use '*:*' for all wildcards, or specify both IP and port like '%s:80'", destination, address)
+	}
+	return nil
+}
+
+func resourceBigipGtmMonitorBigip() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBigipGtmMonitorBigipCreate,
+		ReadContext:   resourceBigipGtmMonitorBigipRead,
+		UpdateContext: resourceBigipGtmMonitorBigipUpdate,
+		DeleteContext: resourceBigipGtmMonitorBigipDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "Name of the GTM BIG-IP monitor",
+				ValidateFunc: validateF5NameWithDirectory,
+			},
+			"defaults_from": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "/Common/bigip",
+				Description: "Inherit properties from this monitor",
+			},
+			"destination": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the IP address and service port of the resource that is the destination of this monitor. Format: ip:port. Default is \"*:*\"",
+				Default:     "*:*",
+			},
+			"interval": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Specifies, in seconds, the frequency at which the system issues the monitor check",
+				Default:     30,
+			},
+			"timeout": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Specifies the number of seconds the target has in which to respond to the monitor request",
+				Default:     90,
+			},
+			"ignore_down_response": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies whether the monitor ignores a down response from the system it is monitoring",
+				Default:     "disabled",
+			},
+			"aggregation_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies how the system combines monitor information for a monitored pool. The default is none",
+				Default:     "none",
+			},
+		},
+	}
+}
+
+func resourceBigipGtmMonitorBigipCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+
+	name := d.Get("name").(string)
+	log.Printf("[INFO] Creating GTM BIG-IP Monitor: %s", name)
+
+	destination := normalizeGtmBigipDestination(d.Get("destination").(string))
+	if err := validateGtmBigipDestination(destination); err != nil {
+		return diag.FromErr(fmt.Errorf("error creating GTM BIG-IP Monitor %s: %v", name, err))
+	}
+
+	monitor := &bigip.Gtmmonitor{
+		Name:                     name,
+		Defaults_from:            d.Get("defaults_from").(string),
+		Destination:              destination,
+		Interval:                 d.Get("interval").(int),
+		Timeout:                  d.Get("timeout").(int),
+		Ignore_down_response:     d.Get("ignore_down_response").(string),
+		Aggregate_dynamic_ratios: d.Get("aggregation_type").(string),
+	}
+
+	err := client.CreateGtmMonitor(monitor, "bigip")
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error creating GTM BIG-IP Monitor %s: %v", name, err))
+	}
+
+	d.SetId(name)
+
+	return resourceBigipGtmMonitorBigipRead(ctx, d, meta)
+}
+
+func resourceBigipGtmMonitorBigipRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+	name := d.Id()
+
+	log.Printf("[INFO] Reading GTM BIG-IP Monitor: %s", name)
+
+	monitor, err := client.GetGtmMonitor(name, "bigip")
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			log.Printf("[WARN] GTM BIG-IP Monitor %s not found, removing from state", name)
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("error reading GTM BIG-IP Monitor %s: %v", name, err))
+	}
+
+	if monitor == nil {
+		log.Printf("[WARN] GTM BIG-IP Monitor %s not found, removing from state", name)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("name", monitor.FullPath)
+	d.Set("defaults_from", monitor.Defaults_from)
+	d.Set("destination", normalizeGtmBigipDestination(monitor.Destination))
+	d.Set("interval", monitor.Interval)
+	d.Set("timeout", monitor.Timeout)
+	d.Set("ignore_down_response", monitor.Ignore_down_response)
+	d.Set("aggregation_type", monitor.Aggregate_dynamic_ratios)
+
+	return nil
+}
+
+func resourceBigipGtmMonitorBigipUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+	name := d.Id()
+
+	log.Printf("[INFO] Updating GTM BIG-IP Monitor: %s", name)
+
+	destination := normalizeGtmBigipDestination(d.Get("destination").(string))
+	if err := validateGtmBigipDestination(destination); err != nil {
+		return diag.FromErr(fmt.Errorf("error updating GTM BIG-IP Monitor %s: %v", name, err))
+	}
+
+	monitor := &bigip.Gtmmonitor{
+		Name:                     name,
+		Defaults_from:            d.Get("defaults_from").(string),
+		Destination:              destination,
+		Interval:                 d.Get("interval").(int),
+		Timeout:                  d.Get("timeout").(int),
+		Ignore_down_response:     d.Get("ignore_down_response").(string),
+		Aggregate_dynamic_ratios: d.Get("aggregation_type").(string),
+	}
+
+	err := client.ModifyGtmMonitor(name, monitor, "bigip")
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error updating GTM BIG-IP Monitor %s: %v", name, err))
+	}
+
+	return resourceBigipGtmMonitorBigipRead(ctx, d, meta)
+}
+
+func resourceBigipGtmMonitorBigipDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+	name := d.Id()
+
+	log.Printf("[INFO] Deleting GTM BIG-IP Monitor: %s", name)
+
+	err := client.DeleteGtmMonitor(name, "bigip")
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			log.Printf("[WARN] GTM BIG-IP Monitor %s not found, removing from state", name)
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("error deleting GTM BIG-IP Monitor %s: %v", name, err))
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/bigip/resource_bigip_gtm_monitor_http.go
+++ b/bigip/resource_bigip_gtm_monitor_http.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2019 F5 Networks Inc.
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+package bigip
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	bigip "github.com/f5devcentral/go-bigip"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceBigipGtmMonitorHttp() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBigipGtmMonitorHttpCreate,
+		ReadContext:   resourceBigipGtmMonitorHttpRead,
+		UpdateContext: resourceBigipGtmMonitorHttpUpdate,
+		DeleteContext: resourceBigipGtmMonitorHttpDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "Name of the GTM HTTP monitor",
+				ValidateFunc: validateF5NameWithDirectory,
+			},
+			"defaults_from": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "/Common/http",
+				Description: "Inherit properties from this monitor",
+			},
+			"destination": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the IP address and service port of the resource that is the destination of this monitor. Format: ip:port. Default is \"*:*\"",
+				Default:     "*:*",
+			},
+			"interval": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Specifies, in seconds, the frequency at which the system issues the monitor check",
+				Default:     30,
+			},
+			"timeout": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Specifies the number of seconds the target has in which to respond to the monitor request",
+				Default:     120,
+			},
+			"probe_timeout": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Specifies the number of seconds after which the BIG-IP system times out the probe request to the BIG-IP system",
+				Default:     5,
+			},
+			"ignore_down_response": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies whether the monitor ignores a down response from the system it is monitoring",
+				Default:     "disabled",
+			},
+			"transparent": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies whether the monitor operates in transparent mode",
+				Default:     "disabled",
+			},
+			"reverse": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Instructs the system to mark the target resource down when the test is successful",
+				Default:     "disabled",
+			},
+			"send": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the text string that the monitor sends to the target object",
+				Default:     "GET /\\r\\n",
+			},
+			"receive": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the text string that the monitor looks for in the returned resource",
+			},
+		},
+	}
+}
+
+func resourceBigipGtmMonitorHttpCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+
+	name := d.Get("name").(string)
+	log.Printf("[INFO] Creating GTM HTTP Monitor: %s", name)
+
+	monitor := &bigip.Gtmmonitor{
+		Name:                 name,
+		Defaults_from:        d.Get("defaults_from").(string),
+		Destination:          d.Get("destination").(string),
+		Interval:             d.Get("interval").(int),
+		Timeout:              d.Get("timeout").(int),
+		Probe_timeout:        d.Get("probe_timeout").(int),
+		Ignore_down_response: d.Get("ignore_down_response").(string),
+		Transparent:          d.Get("transparent").(string),
+		Reverse:              d.Get("reverse").(string),
+		Send:                 d.Get("send").(string),
+		Recv:                 d.Get("receive").(string),
+	}
+
+	err := client.CreateGtmMonitor(monitor, "http")
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error creating GTM HTTP Monitor %s: %v", name, err))
+	}
+
+	d.SetId(name)
+
+	return resourceBigipGtmMonitorHttpRead(ctx, d, meta)
+}
+
+func resourceBigipGtmMonitorHttpRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+	name := d.Id()
+
+	log.Printf("[INFO] Reading GTM HTTP Monitor: %s", name)
+
+	monitor, err := client.GetGtmMonitor(name, "http")
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			log.Printf("[WARN] GTM HTTP Monitor %s not found, removing from state", name)
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("error reading GTM HTTP Monitor %s: %v", name, err))
+	}
+
+	if monitor == nil {
+		log.Printf("[WARN] GTM HTTP Monitor %s not found, removing from state", name)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("name", monitor.FullPath)
+	d.Set("defaults_from", monitor.Defaults_from)
+	d.Set("destination", monitor.Destination)
+	d.Set("interval", monitor.Interval)
+	d.Set("timeout", monitor.Timeout)
+	d.Set("probe_timeout", monitor.Probe_timeout)
+	d.Set("ignore_down_response", monitor.Ignore_down_response)
+	d.Set("transparent", monitor.Transparent)
+	d.Set("reverse", monitor.Reverse)
+	d.Set("send", monitor.Send)
+	d.Set("receive", monitor.Recv)
+
+	return nil
+}
+
+func resourceBigipGtmMonitorHttpUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+	name := d.Id()
+
+	log.Printf("[INFO] Updating GTM HTTP Monitor: %s", name)
+
+	monitor := &bigip.Gtmmonitor{
+		Name:                 name,
+		Defaults_from:        d.Get("defaults_from").(string),
+		Destination:          d.Get("destination").(string),
+		Interval:             d.Get("interval").(int),
+		Timeout:              d.Get("timeout").(int),
+		Probe_timeout:        d.Get("probe_timeout").(int),
+		Ignore_down_response: d.Get("ignore_down_response").(string),
+		Transparent:          d.Get("transparent").(string),
+		Reverse:              d.Get("reverse").(string),
+		Send:                 d.Get("send").(string),
+		Recv:                 d.Get("receive").(string),
+	}
+
+	err := client.ModifyGtmMonitor(name, monitor, "http")
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error updating GTM HTTP Monitor %s: %v", name, err))
+	}
+
+	return resourceBigipGtmMonitorHttpRead(ctx, d, meta)
+}
+
+func resourceBigipGtmMonitorHttpDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+	name := d.Id()
+
+	log.Printf("[INFO] Deleting GTM HTTP Monitor: %s", name)
+
+	err := client.DeleteGtmMonitor(name, "http")
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			log.Printf("[WARN] GTM HTTP Monitor %s not found, removing from state", name)
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("error deleting GTM HTTP Monitor %s: %v", name, err))
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/bigip/resource_bigip_gtm_monitor_http.go
+++ b/bigip/resource_bigip_gtm_monitor_http.go
@@ -86,7 +86,7 @@ func resourceBigipGtmMonitorHttp() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Specifies the text string that the monitor sends to the target object",
-				Default:     "GET /\\r\\n",
+				Default:     "GET /",
 			},
 			"receive": {
 				Type:        schema.TypeString,

--- a/bigip/resource_bigip_gtm_monitor_https.go
+++ b/bigip/resource_bigip_gtm_monitor_https.go
@@ -86,7 +86,7 @@ func resourceBigipGtmMonitorHttps() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Specifies the text string that the monitor sends to the target object",
-				Default:     "GET /\\r\\n",
+				Default:     "GET /",
 			},
 			"receive": {
 				Type:        schema.TypeString,
@@ -107,7 +107,7 @@ func resourceBigipGtmMonitorHttps() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Specifies the list of ciphers for this monitor",
-				Default:     "DEFAULT:+SHA:+3DES:+kEDH",
+				Default:     "DEFAULT:!EXPORT",
 			},
 			"compatibility": {
 				Type:        schema.TypeString,

--- a/bigip/resource_bigip_gtm_monitor_https.go
+++ b/bigip/resource_bigip_gtm_monitor_https.go
@@ -1,0 +1,247 @@
+/*
+Copyright 2019 F5 Networks Inc.
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+package bigip
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	bigip "github.com/f5devcentral/go-bigip"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceBigipGtmMonitorHttps() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBigipGtmMonitorHttpsCreate,
+		ReadContext:   resourceBigipGtmMonitorHttpsRead,
+		UpdateContext: resourceBigipGtmMonitorHttpsUpdate,
+		DeleteContext: resourceBigipGtmMonitorHttpsDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "Name of the GTM HTTPS monitor",
+				ValidateFunc: validateF5NameWithDirectory,
+			},
+			"defaults_from": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "/Common/https",
+				Description: "Inherit properties from this monitor",
+			},
+			"destination": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the IP address and service port of the resource that is the destination of this monitor. Format: ip:port. Default is \"*:*\"",
+				Default:     "*:*",
+			},
+			"interval": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Specifies, in seconds, the frequency at which the system issues the monitor check",
+				Default:     30,
+			},
+			"timeout": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Specifies the number of seconds the target has in which to respond to the monitor request",
+				Default:     120,
+			},
+			"probe_timeout": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Specifies the number of seconds after which the BIG-IP system times out the probe request to the BIG-IP system",
+				Default:     5,
+			},
+			"ignore_down_response": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies whether the monitor ignores a down response from the system it is monitoring",
+				Default:     "disabled",
+			},
+			"transparent": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies whether the monitor operates in transparent mode",
+				Default:     "disabled",
+			},
+			"reverse": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Instructs the system to mark the target resource down when the test is successful",
+				Default:     "disabled",
+			},
+			"send": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the text string that the monitor sends to the target object",
+				Default:     "GET /\\r\\n",
+			},
+			"receive": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the text string that the monitor looks for in the returned resource",
+			},
+			"cert": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies a fully-qualified path for a client certificate that the monitor sends to the target SSL server",
+			},
+			"key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the key for the client certificate that the monitor sends to the target SSL server",
+			},
+			"cipherlist": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the list of ciphers for this monitor",
+				Default:     "DEFAULT:+SHA:+3DES:+kEDH",
+			},
+			"compatibility": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the SSL version compatibility",
+				Default:     "enabled",
+			},
+		},
+	}
+}
+
+func resourceBigipGtmMonitorHttpsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+
+	name := d.Get("name").(string)
+	log.Printf("[INFO] Creating GTM HTTPS Monitor: %s", name)
+
+	monitor := &bigip.Gtmmonitor{
+		Name:                 name,
+		Defaults_from:        d.Get("defaults_from").(string),
+		Destination:          d.Get("destination").(string),
+		Interval:             d.Get("interval").(int),
+		Timeout:              d.Get("timeout").(int),
+		Probe_timeout:        d.Get("probe_timeout").(int),
+		Ignore_down_response: d.Get("ignore_down_response").(string),
+		Transparent:          d.Get("transparent").(string),
+		Reverse:              d.Get("reverse").(string),
+		Send:                 d.Get("send").(string),
+		Recv:                 d.Get("receive").(string),
+		Cert:                 d.Get("cert").(string),
+		Key:                  d.Get("key").(string),
+		Cipherlist:           d.Get("cipherlist").(string),
+		Compatibility:        d.Get("compatibility").(string),
+	}
+
+	err := client.CreateGtmMonitor(monitor, "https")
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error creating GTM HTTPS Monitor %s: %v", name, err))
+	}
+
+	d.SetId(name)
+
+	return resourceBigipGtmMonitorHttpsRead(ctx, d, meta)
+}
+
+func resourceBigipGtmMonitorHttpsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+	name := d.Id()
+
+	log.Printf("[INFO] Reading GTM HTTPS Monitor: %s", name)
+
+	monitor, err := client.GetGtmMonitor(name, "https")
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			log.Printf("[WARN] GTM HTTPS Monitor %s not found, removing from state", name)
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("error reading GTM HTTPS Monitor %s: %v", name, err))
+	}
+
+	if monitor == nil {
+		log.Printf("[WARN] GTM HTTPS Monitor %s not found, removing from state", name)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("name", monitor.FullPath)
+	d.Set("defaults_from", monitor.Defaults_from)
+	d.Set("destination", monitor.Destination)
+	d.Set("interval", monitor.Interval)
+	d.Set("timeout", monitor.Timeout)
+	d.Set("probe_timeout", monitor.Probe_timeout)
+	d.Set("ignore_down_response", monitor.Ignore_down_response)
+	d.Set("transparent", monitor.Transparent)
+	d.Set("reverse", monitor.Reverse)
+	d.Set("send", monitor.Send)
+	d.Set("receive", monitor.Recv)
+	d.Set("cert", monitor.Cert)
+	d.Set("key", monitor.Key)
+	d.Set("cipherlist", monitor.Cipherlist)
+	d.Set("compatibility", monitor.Compatibility)
+
+	return nil
+}
+
+func resourceBigipGtmMonitorHttpsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+	name := d.Id()
+
+	log.Printf("[INFO] Updating GTM HTTPS Monitor: %s", name)
+
+	monitor := &bigip.Gtmmonitor{
+		Name:                 name,
+		Defaults_from:        d.Get("defaults_from").(string),
+		Destination:          d.Get("destination").(string),
+		Interval:             d.Get("interval").(int),
+		Timeout:              d.Get("timeout").(int),
+		Probe_timeout:        d.Get("probe_timeout").(int),
+		Ignore_down_response: d.Get("ignore_down_response").(string),
+		Transparent:          d.Get("transparent").(string),
+		Reverse:              d.Get("reverse").(string),
+		Send:                 d.Get("send").(string),
+		Recv:                 d.Get("receive").(string),
+		Cert:                 d.Get("cert").(string),
+		Key:                  d.Get("key").(string),
+		Cipherlist:           d.Get("cipherlist").(string),
+		Compatibility:        d.Get("compatibility").(string),
+	}
+
+	err := client.ModifyGtmMonitor(name, monitor, "https")
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error updating GTM HTTPS Monitor %s: %v", name, err))
+	}
+
+	return resourceBigipGtmMonitorHttpsRead(ctx, d, meta)
+}
+
+func resourceBigipGtmMonitorHttpsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+	name := d.Id()
+
+	log.Printf("[INFO] Deleting GTM HTTPS Monitor: %s", name)
+
+	err := client.DeleteGtmMonitor(name, "https")
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			log.Printf("[WARN] GTM HTTPS Monitor %s not found, removing from state", name)
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("error deleting GTM HTTPS Monitor %s: %v", name, err))
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/bigip/resource_bigip_gtm_monitor_postgresql.go
+++ b/bigip/resource_bigip_gtm_monitor_postgresql.go
@@ -89,6 +89,7 @@ func resourceBigipGtmMonitorPostgresql() *schema.Resource {
 			"probe_count": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "Specifies the number of monitor probes after which the system times out",
 			},
 			"debug": {

--- a/bigip/resource_bigip_gtm_monitor_postgresql.go
+++ b/bigip/resource_bigip_gtm_monitor_postgresql.go
@@ -56,7 +56,7 @@ func resourceBigipGtmMonitorPostgresql() *schema.Resource {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "Specifies the number of seconds the target has in which to respond to the monitor request",
-				Default:     120,
+				Default:     91,
 			},
 			"probe_timeout": {
 				Type:        schema.TypeInt,

--- a/bigip/resource_bigip_gtm_monitor_postgresql.go
+++ b/bigip/resource_bigip_gtm_monitor_postgresql.go
@@ -90,7 +90,7 @@ func resourceBigipGtmMonitorPostgresql() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				Description: "Specifies the number of monitor probes after which the system times out",
+				Description: "Specifies the number of instances for which the system keeps a connection open",
 			},
 			"debug": {
 				Type:        schema.TypeString,

--- a/bigip/resource_bigip_gtm_monitor_postgresql.go
+++ b/bigip/resource_bigip_gtm_monitor_postgresql.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2019 F5 Networks Inc.
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+package bigip
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	bigip "github.com/f5devcentral/go-bigip"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceBigipGtmMonitorPostgresql() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBigipGtmMonitorPostgresqlCreate,
+		ReadContext:   resourceBigipGtmMonitorPostgresqlRead,
+		UpdateContext: resourceBigipGtmMonitorPostgresqlUpdate,
+		DeleteContext: resourceBigipGtmMonitorPostgresqlDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "Name of the GTM PostgreSQL monitor",
+				ValidateFunc: validateF5NameWithDirectory,
+			},
+			"defaults_from": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "/Common/postgresql",
+				Description: "Inherit properties from this monitor",
+			},
+			"destination": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the IP address and service port of the resource that is the destination of this monitor. Format: ip:port. Default is \"*:*\"",
+				Default:     "*:*",
+			},
+			"interval": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Specifies, in seconds, the frequency at which the system issues the monitor check",
+				Default:     30,
+			},
+			"timeout": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Specifies the number of seconds the target has in which to respond to the monitor request",
+				Default:     120,
+			},
+			"probe_timeout": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Specifies the number of seconds after which the BIG-IP system times out the probe request to the BIG-IP system",
+				Default:     5,
+			},
+			"ignore_down_response": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies whether the monitor ignores a down response from the system it is monitoring",
+				Default:     "disabled",
+			},
+			"database": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the database in which the user is created",
+			},
+			"username": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the user name if the monitored target requires authentication",
+			},
+			"password": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Description: "Specifies the password if the monitored target requires authentication",
+			},
+			"probe_count": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the number of monitor probes after which the system times out",
+			},
+			"debug": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies whether the monitor sends error messages and additional information to a log file created and labeled specifically for this monitor",
+				Default:     "no",
+			},
+			"receive": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the text string that the monitor looks for in the returned resource",
+			},
+		},
+	}
+}
+
+func resourceBigipGtmMonitorPostgresqlCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+
+	name := d.Get("name").(string)
+	log.Printf("[INFO] Creating GTM PostgreSQL Monitor: %s", name)
+
+	monitor := &bigip.Gtmmonitor{
+		Name:                 name,
+		Defaults_from:        d.Get("defaults_from").(string),
+		Destination:          d.Get("destination").(string),
+		Interval:             d.Get("interval").(int),
+		Timeout:              d.Get("timeout").(int),
+		Probe_timeout:        d.Get("probe_timeout").(int),
+		Ignore_down_response: d.Get("ignore_down_response").(string),
+		Database:             d.Get("database").(string),
+		Username:             d.Get("username").(string),
+		Password:             d.Get("password").(string),
+		Count:                d.Get("probe_count").(string),
+		Debug:                d.Get("debug").(string),
+		Recv:                 d.Get("receive").(string),
+	}
+
+	err := client.CreateGtmMonitor(monitor, "postgresql")
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error creating GTM PostgreSQL Monitor %s: %v", name, err))
+	}
+
+	d.SetId(name)
+
+	return resourceBigipGtmMonitorPostgresqlRead(ctx, d, meta)
+}
+
+func resourceBigipGtmMonitorPostgresqlRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+	name := d.Id()
+
+	log.Printf("[INFO] Reading GTM PostgreSQL Monitor: %s", name)
+
+	monitor, err := client.GetGtmMonitor(name, "postgresql")
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			log.Printf("[WARN] GTM PostgreSQL Monitor %s not found, removing from state", name)
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("error reading GTM PostgreSQL Monitor %s: %v", name, err))
+	}
+
+	if monitor == nil {
+		log.Printf("[WARN] GTM PostgreSQL Monitor %s not found, removing from state", name)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("name", monitor.FullPath)
+	d.Set("defaults_from", monitor.Defaults_from)
+	d.Set("destination", monitor.Destination)
+	d.Set("interval", monitor.Interval)
+	d.Set("timeout", monitor.Timeout)
+	d.Set("probe_timeout", monitor.Probe_timeout)
+	d.Set("ignore_down_response", monitor.Ignore_down_response)
+	d.Set("database", monitor.Database)
+	d.Set("username", monitor.Username)
+	// Password is sensitive, don't set it back
+	d.Set("probe_count", monitor.Count)
+	d.Set("debug", monitor.Debug)
+	d.Set("receive", monitor.Recv)
+
+	return nil
+}
+
+func resourceBigipGtmMonitorPostgresqlUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+	name := d.Id()
+
+	log.Printf("[INFO] Updating GTM PostgreSQL Monitor: %s", name)
+
+	monitor := &bigip.Gtmmonitor{
+		Name:                 name,
+		Defaults_from:        d.Get("defaults_from").(string),
+		Destination:          d.Get("destination").(string),
+		Interval:             d.Get("interval").(int),
+		Timeout:              d.Get("timeout").(int),
+		Probe_timeout:        d.Get("probe_timeout").(int),
+		Ignore_down_response: d.Get("ignore_down_response").(string),
+		Database:             d.Get("database").(string),
+		Username:             d.Get("username").(string),
+		Password:             d.Get("password").(string),
+		Count:                d.Get("probe_count").(string),
+		Debug:                d.Get("debug").(string),
+		Recv:                 d.Get("receive").(string),
+	}
+
+	err := client.ModifyGtmMonitor(name, monitor, "postgresql")
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error updating GTM PostgreSQL Monitor %s: %v", name, err))
+	}
+
+	return resourceBigipGtmMonitorPostgresqlRead(ctx, d, meta)
+}
+
+func resourceBigipGtmMonitorPostgresqlDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+	name := d.Id()
+
+	log.Printf("[INFO] Deleting GTM PostgreSQL Monitor: %s", name)
+
+	err := client.DeleteGtmMonitor(name, "postgresql")
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			log.Printf("[WARN] GTM PostgreSQL Monitor %s not found, removing from state", name)
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("error deleting GTM PostgreSQL Monitor %s: %v", name, err))
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/bigip/resource_bigip_gtm_monitor_postgresql.go
+++ b/bigip/resource_bigip_gtm_monitor_postgresql.go
@@ -86,7 +86,7 @@ func resourceBigipGtmMonitorPostgresql() *schema.Resource {
 				Sensitive:   true,
 				Description: "Specifies the password if the monitored target requires authentication",
 			},
-			"probe_count": {
+			"instance_count": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
@@ -124,7 +124,7 @@ func resourceBigipGtmMonitorPostgresqlCreate(ctx context.Context, d *schema.Reso
 		Database:             d.Get("database").(string),
 		Username:             d.Get("username").(string),
 		Password:             d.Get("password").(string),
-		Count:                d.Get("probe_count").(string),
+		Count:                d.Get("instance_count").(string),
 		Debug:                d.Get("debug").(string),
 		Recv:                 d.Get("receive").(string),
 	}
@@ -171,7 +171,7 @@ func resourceBigipGtmMonitorPostgresqlRead(ctx context.Context, d *schema.Resour
 	d.Set("database", monitor.Database)
 	d.Set("username", monitor.Username)
 	// Password is sensitive, don't set it back
-	d.Set("probe_count", monitor.Count)
+	d.Set("instance_count", monitor.Count)
 	d.Set("debug", monitor.Debug)
 	d.Set("receive", monitor.Recv)
 
@@ -195,7 +195,7 @@ func resourceBigipGtmMonitorPostgresqlUpdate(ctx context.Context, d *schema.Reso
 		Database:             d.Get("database").(string),
 		Username:             d.Get("username").(string),
 		Password:             d.Get("password").(string),
-		Count:                d.Get("probe_count").(string),
+		Count:                d.Get("instance_count").(string),
 		Debug:                d.Get("debug").(string),
 		Recv:                 d.Get("receive").(string),
 	}

--- a/bigip/resource_bigip_gtm_monitor_tcp.go
+++ b/bigip/resource_bigip_gtm_monitor_tcp.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2019 F5 Networks Inc.
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+package bigip
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	bigip "github.com/f5devcentral/go-bigip"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceBigipGtmMonitorTcp() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBigipGtmMonitorTcpCreate,
+		ReadContext:   resourceBigipGtmMonitorTcpRead,
+		UpdateContext: resourceBigipGtmMonitorTcpUpdate,
+		DeleteContext: resourceBigipGtmMonitorTcpDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "Name of the GTM TCP monitor",
+				ValidateFunc: validateF5NameWithDirectory,
+			},
+			"defaults_from": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "/Common/tcp",
+				Description: "Inherit properties from this monitor",
+			},
+			"destination": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the IP address and service port of the resource that is the destination of this monitor. Format: ip:port. Default is \"*:*\"",
+				Default:     "*:*",
+			},
+			"interval": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Specifies, in seconds, the frequency at which the system issues the monitor check",
+				Default:     30,
+			},
+			"timeout": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Specifies the number of seconds the target has in which to respond to the monitor request",
+				Default:     120,
+			},
+			"probe_timeout": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Specifies the number of seconds after which the BIG-IP system times out the probe request to the BIG-IP system",
+				Default:     5,
+			},
+			"ignore_down_response": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies whether the monitor ignores a down response from the system it is monitoring",
+				Default:     "disabled",
+			},
+			"transparent": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies whether the monitor operates in transparent mode",
+				Default:     "disabled",
+			},
+			"reverse": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Instructs the system to mark the target resource down when the test is successful",
+				Default:     "disabled",
+			},
+			"send": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the text string that the monitor sends to the target object",
+			},
+			"receive": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the text string that the monitor looks for in the returned resource",
+			},
+		},
+	}
+}
+
+func resourceBigipGtmMonitorTcpCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+
+	name := d.Get("name").(string)
+	log.Printf("[INFO] Creating GTM TCP Monitor: %s", name)
+
+	monitor := &bigip.Gtmmonitor{
+		Name:                 name,
+		Defaults_from:        d.Get("defaults_from").(string),
+		Destination:          d.Get("destination").(string),
+		Interval:             d.Get("interval").(int),
+		Timeout:              d.Get("timeout").(int),
+		Probe_timeout:        d.Get("probe_timeout").(int),
+		Ignore_down_response: d.Get("ignore_down_response").(string),
+		Transparent:          d.Get("transparent").(string),
+		Reverse:              d.Get("reverse").(string),
+		Send:                 d.Get("send").(string),
+		Recv:                 d.Get("receive").(string),
+	}
+
+	err := client.CreateGtmMonitor(monitor, "tcp")
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error creating GTM TCP Monitor %s: %v", name, err))
+	}
+
+	d.SetId(name)
+
+	return resourceBigipGtmMonitorTcpRead(ctx, d, meta)
+}
+
+func resourceBigipGtmMonitorTcpRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+	name := d.Id()
+
+	log.Printf("[INFO] Reading GTM TCP Monitor: %s", name)
+
+	monitor, err := client.GetGtmMonitor(name, "tcp")
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			log.Printf("[WARN] GTM TCP Monitor %s not found, removing from state", name)
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("error reading GTM TCP Monitor %s: %v", name, err))
+	}
+
+	if monitor == nil {
+		log.Printf("[WARN] GTM TCP Monitor %s not found, removing from state", name)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("name", monitor.FullPath)
+	d.Set("defaults_from", monitor.Defaults_from)
+	d.Set("destination", monitor.Destination)
+	d.Set("interval", monitor.Interval)
+	d.Set("timeout", monitor.Timeout)
+	d.Set("probe_timeout", monitor.Probe_timeout)
+	d.Set("ignore_down_response", monitor.Ignore_down_response)
+	d.Set("transparent", monitor.Transparent)
+	d.Set("reverse", monitor.Reverse)
+	d.Set("send", monitor.Send)
+	d.Set("receive", monitor.Recv)
+
+	return nil
+}
+
+func resourceBigipGtmMonitorTcpUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+	name := d.Id()
+
+	log.Printf("[INFO] Updating GTM TCP Monitor: %s", name)
+
+	monitor := &bigip.Gtmmonitor{
+		Name:                 name,
+		Defaults_from:        d.Get("defaults_from").(string),
+		Destination:          d.Get("destination").(string),
+		Interval:             d.Get("interval").(int),
+		Timeout:              d.Get("timeout").(int),
+		Probe_timeout:        d.Get("probe_timeout").(int),
+		Ignore_down_response: d.Get("ignore_down_response").(string),
+		Transparent:          d.Get("transparent").(string),
+		Reverse:              d.Get("reverse").(string),
+		Send:                 d.Get("send").(string),
+		Recv:                 d.Get("receive").(string),
+	}
+
+	err := client.ModifyGtmMonitor(name, monitor, "tcp")
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error updating GTM TCP Monitor %s: %v", name, err))
+	}
+
+	return resourceBigipGtmMonitorTcpRead(ctx, d, meta)
+}
+
+func resourceBigipGtmMonitorTcpDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+	name := d.Id()
+
+	log.Printf("[INFO] Deleting GTM TCP Monitor: %s", name)
+
+	err := client.DeleteGtmMonitor(name, "tcp")
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			log.Printf("[WARN] GTM TCP Monitor %s not found, removing from state", name)
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("error deleting GTM TCP Monitor %s: %v", name, err))
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/bigip/resource_bigip_gtm_monitor_test.go
+++ b/bigip/resource_bigip_gtm_monitor_test.go
@@ -1,0 +1,658 @@
+/*
+Copyright 2019 F5 Networks Inc.
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+package bigip
+
+import (
+	"fmt"
+	"testing"
+
+	bigip "github.com/f5devcentral/go-bigip"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+var TestGtmMonitorHttpResource = `
+resource "bigip_gtm_monitor_http" "test-gtm-http-monitor" {
+  name                  = "/Common/test-gtm-http-monitor"
+  defaults_from         = "/Common/http"
+  destination           = "*:*"
+  interval              = 30
+  timeout               = 120
+  probe_timeout         = 5
+  ignore_down_response  = "disabled"
+  transparent           = "disabled"
+  reverse               = "disabled"
+  send                  = "GET /\\r\\n"
+  receive              = "200 OK"
+}
+`
+
+var TestGtmMonitorHttpsResource = `
+resource "bigip_gtm_monitor_https" "test-gtm-https-monitor" {
+  name                  = "/Common/test-gtm-https-monitor"
+  defaults_from         = "/Common/https"
+  destination           = "*:*"
+  interval              = 30
+  timeout               = 120
+  probe_timeout         = 5
+  ignore_down_response  = "disabled"
+  transparent           = "disabled"
+  reverse               = "disabled"
+  send                  = "GET /\\r\\n"
+  receive              = "200 OK"
+  cipherlist           = "DEFAULT:+SHA:+3DES:+kEDH"
+  compatibility        = "enabled"
+}
+`
+
+var TestGtmMonitorTcpResource = `
+resource "bigip_gtm_monitor_tcp" "test-gtm-tcp-monitor" {
+  name                  = "/Common/test-gtm-tcp-monitor"
+  defaults_from         = "/Common/tcp"
+  destination           = "*:*"
+  interval              = 30
+  timeout               = 120
+  probe_timeout         = 5
+  ignore_down_response  = "disabled"
+  transparent           = "disabled"
+  reverse               = "disabled"
+}
+`
+
+var TestGtmMonitorPostgresqlResource = `
+resource "bigip_gtm_monitor_postgresql" "test-gtm-postgresql-monitor" {
+  name                  = "/Common/test-gtm-postgresql-monitor"
+  defaults_from         = "/Common/postgresql"
+  destination           = "*:5432"
+  interval              = 30
+  timeout               = 120
+  probe_timeout         = 5
+  ignore_down_response  = "disabled"
+  database              = "testdb"
+  username              = "testuser"
+  debug                 = "no"
+}
+`
+
+var TestGtmMonitorBigipResource = `
+resource "bigip_gtm_monitor_bigip" "test-gtm-bigip-monitor" {
+  name                  = "/Common/test-gtm-bigip-monitor"
+  defaults_from         = "/Common/bigip"
+  destination           = "*:*"
+  interval              = 30
+  timeout               = 90
+  ignore_down_response  = "disabled"
+  aggregation_type      = "none"
+}
+`
+
+var TestGtmMonitorHttpResourceUpdate = `
+resource "bigip_gtm_monitor_http" "test-gtm-http-monitor" {
+  name                  = "/Common/test-gtm-http-monitor"
+  defaults_from         = "/Common/http"
+  destination           = "10.1.1.100:8080"
+  interval              = 60
+  timeout               = 180
+  probe_timeout         = 10
+  ignore_down_response  = "enabled"
+  transparent           = "enabled"
+  reverse               = "enabled"
+  send                  = "GET /health\\r\\n"
+  receive              = "healthy"
+}
+`
+
+var TestGtmMonitorHttpsResourceUpdate = `
+resource "bigip_gtm_monitor_https" "test-gtm-https-monitor" {
+  name                  = "/Common/test-gtm-https-monitor"
+  defaults_from         = "/Common/https"
+  destination           = "10.1.1.100:8443"
+  interval              = 45
+  timeout               = 180
+  probe_timeout         = 10
+  ignore_down_response  = "enabled"
+  transparent           = "enabled"
+  reverse               = "disabled"
+  send                  = "GET /api/health\\r\\n"
+  receive              = "status: ok"
+  cipherlist           = "HIGH:!ADH:!MD5"
+  compatibility        = "disabled"
+}
+`
+
+var TestGtmMonitorTcpResourceMinimal = `
+resource "bigip_gtm_monitor_tcp" "test-gtm-tcp-monitor-minimal" {
+  name = "/Common/test-gtm-tcp-monitor-minimal"
+}
+`
+
+var TestGtmMonitorPostgresqlResourceUpdate = `
+resource "bigip_gtm_monitor_postgresql" "test-gtm-postgresql-monitor" {
+  name                  = "/Common/test-gtm-postgresql-monitor"
+  defaults_from         = "/Common/postgresql"
+  destination           = "192.168.1.50:5432"
+  interval              = 45
+  timeout               = 91
+  probe_timeout         = 10
+  ignore_down_response  = "enabled"
+  database              = "production"
+  username              = "produser"
+  debug                 = "yes"
+}
+`
+
+func TestAccBigipGtmMonitorHttp_create(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckGtmMonitorHttpDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: TestGtmMonitorHttpResource,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckGtmMonitorHttpExists("/Common/test-gtm-http-monitor", true),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_http.test-gtm-http-monitor", "name", "/Common/test-gtm-http-monitor"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_http.test-gtm-http-monitor", "defaults_from", "/Common/http"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_http.test-gtm-http-monitor", "interval", "30"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_http.test-gtm-http-monitor", "timeout", "120"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_http.test-gtm-http-monitor", "send", "GET /\\r\\n"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBigipGtmMonitorHttps_create(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckGtmMonitorHttpsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: TestGtmMonitorHttpsResource,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckGtmMonitorHttpsExists("/Common/test-gtm-https-monitor", true),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_https.test-gtm-https-monitor", "name", "/Common/test-gtm-https-monitor"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_https.test-gtm-https-monitor", "defaults_from", "/Common/https"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_https.test-gtm-https-monitor", "interval", "30"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_https.test-gtm-https-monitor", "timeout", "120"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_https.test-gtm-https-monitor", "cipherlist", "DEFAULT:+SHA:+3DES:+kEDH"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBigipGtmMonitorTcp_create(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckGtmMonitorTcpDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: TestGtmMonitorTcpResource,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckGtmMonitorTcpExists("/Common/test-gtm-tcp-monitor", true),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_tcp.test-gtm-tcp-monitor", "name", "/Common/test-gtm-tcp-monitor"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_tcp.test-gtm-tcp-monitor", "defaults_from", "/Common/tcp"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_tcp.test-gtm-tcp-monitor", "interval", "30"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_tcp.test-gtm-tcp-monitor", "timeout", "120"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBigipGtmMonitorPostgresql_create(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckGtmMonitorPostgresqlDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: TestGtmMonitorPostgresqlResource,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckGtmMonitorPostgresqlExists("/Common/test-gtm-postgresql-monitor", true),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_postgresql.test-gtm-postgresql-monitor", "name", "/Common/test-gtm-postgresql-monitor"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_postgresql.test-gtm-postgresql-monitor", "defaults_from", "/Common/postgresql"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_postgresql.test-gtm-postgresql-monitor", "database", "testdb"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_postgresql.test-gtm-postgresql-monitor", "username", "testuser"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBigipGtmMonitorBigip_create(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckGtmMonitorBigipDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: TestGtmMonitorBigipResource,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckGtmMonitorBigipExists("/Common/test-gtm-bigip-monitor", true),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_bigip.test-gtm-bigip-monitor", "name", "/Common/test-gtm-bigip-monitor"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_bigip.test-gtm-bigip-monitor", "defaults_from", "/Common/bigip"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_bigip.test-gtm-bigip-monitor", "aggregation_type", "none"),
+				),
+			},
+		},
+	})
+}
+
+func testCheckGtmMonitorHttpExists(name string, exists bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*bigip.BigIP)
+		monitor, err := client.GetGtmMonitor(name, "http")
+		if err != nil {
+			return err
+		}
+		if exists && monitor == nil {
+			return fmt.Errorf("GTM HTTP Monitor %s was not created", name)
+		}
+		if !exists && monitor != nil {
+			return fmt.Errorf("GTM HTTP Monitor %s still exists", name)
+		}
+		return nil
+	}
+}
+
+func testCheckGtmMonitorHttpDestroyed(s *terraform.State) error {
+	client := testAccProvider.Meta().(*bigip.BigIP)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "bigip_gtm_monitor_http" {
+			continue
+		}
+		name := rs.Primary.ID
+		monitor, err := client.GetGtmMonitor(name, "http")
+		if err != nil {
+			return err
+		}
+		if monitor != nil {
+			return fmt.Errorf("GTM HTTP Monitor %s not destroyed", name)
+		}
+	}
+	return nil
+}
+
+func testCheckGtmMonitorHttpsExists(name string, exists bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*bigip.BigIP)
+		monitor, err := client.GetGtmMonitor(name, "https")
+		if err != nil {
+			return err
+		}
+		if exists && monitor == nil {
+			return fmt.Errorf("GTM HTTPS Monitor %s was not created", name)
+		}
+		if !exists && monitor != nil {
+			return fmt.Errorf("GTM HTTPS Monitor %s still exists", name)
+		}
+		return nil
+	}
+}
+
+func testCheckGtmMonitorHttpsDestroyed(s *terraform.State) error {
+	client := testAccProvider.Meta().(*bigip.BigIP)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "bigip_gtm_monitor_https" {
+			continue
+		}
+		name := rs.Primary.ID
+		monitor, err := client.GetGtmMonitor(name, "https")
+		if err != nil {
+			return err
+		}
+		if monitor != nil {
+			return fmt.Errorf("GTM HTTPS Monitor %s not destroyed", name)
+		}
+	}
+	return nil
+}
+
+func testCheckGtmMonitorTcpExists(name string, exists bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*bigip.BigIP)
+		monitor, err := client.GetGtmMonitor(name, "tcp")
+		if err != nil {
+			return err
+		}
+		if exists && monitor == nil {
+			return fmt.Errorf("GTM TCP Monitor %s was not created", name)
+		}
+		if !exists && monitor != nil {
+			return fmt.Errorf("GTM TCP Monitor %s still exists", name)
+		}
+		return nil
+	}
+}
+
+func testCheckGtmMonitorTcpDestroyed(s *terraform.State) error {
+	client := testAccProvider.Meta().(*bigip.BigIP)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "bigip_gtm_monitor_tcp" {
+			continue
+		}
+		name := rs.Primary.ID
+		monitor, err := client.GetGtmMonitor(name, "tcp")
+		if err != nil {
+			return err
+		}
+		if monitor != nil {
+			return fmt.Errorf("GTM TCP Monitor %s not destroyed", name)
+		}
+	}
+	return nil
+}
+
+func testCheckGtmMonitorPostgresqlExists(name string, exists bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*bigip.BigIP)
+		monitor, err := client.GetGtmMonitor(name, "postgresql")
+		if err != nil {
+			return err
+		}
+		if exists && monitor == nil {
+			return fmt.Errorf("GTM PostgreSQL Monitor %s was not created", name)
+		}
+		if !exists && monitor != nil {
+			return fmt.Errorf("GTM PostgreSQL Monitor %s still exists", name)
+		}
+		return nil
+	}
+}
+
+func testCheckGtmMonitorPostgresqlDestroyed(s *terraform.State) error {
+	client := testAccProvider.Meta().(*bigip.BigIP)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "bigip_gtm_monitor_postgresql" {
+			continue
+		}
+		name := rs.Primary.ID
+		monitor, err := client.GetGtmMonitor(name, "postgresql")
+		if err != nil {
+			return err
+		}
+		if monitor != nil {
+			return fmt.Errorf("GTM PostgreSQL Monitor %s not destroyed", name)
+		}
+	}
+	return nil
+}
+
+func testCheckGtmMonitorBigipExists(name string, exists bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*bigip.BigIP)
+		monitor, err := client.GetGtmMonitor(name, "bigip")
+		if err != nil {
+			return err
+		}
+		if exists && monitor == nil {
+			return fmt.Errorf("GTM BIG-IP Monitor %s was not created", name)
+		}
+		if !exists && monitor != nil {
+			return fmt.Errorf("GTM BIG-IP Monitor %s still exists", name)
+		}
+		return nil
+	}
+}
+
+func testCheckGtmMonitorBigipDestroyed(s *terraform.State) error {
+	client := testAccProvider.Meta().(*bigip.BigIP)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "bigip_gtm_monitor_bigip" {
+			continue
+		}
+		name := rs.Primary.ID
+		monitor, err := client.GetGtmMonitor(name, "bigip")
+		if err != nil {
+			return err
+		}
+		if monitor != nil {
+			return fmt.Errorf("GTM BIG-IP Monitor %s not destroyed", name)
+		}
+	}
+	return nil
+}
+
+// Update tests - verify resource modifications work correctly
+
+func TestAccBigipGtmMonitorHttp_update(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckGtmMonitorHttpDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: TestGtmMonitorHttpResource,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckGtmMonitorHttpExists("/Common/test-gtm-http-monitor", true),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_http.test-gtm-http-monitor", "interval", "30"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_http.test-gtm-http-monitor", "timeout", "120"),
+				),
+			},
+			{
+				Config: TestGtmMonitorHttpResourceUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckGtmMonitorHttpExists("/Common/test-gtm-http-monitor", true),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_http.test-gtm-http-monitor", "destination", "10.1.1.100:8080"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_http.test-gtm-http-monitor", "interval", "60"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_http.test-gtm-http-monitor", "timeout", "180"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_http.test-gtm-http-monitor", "probe_timeout", "10"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_http.test-gtm-http-monitor", "ignore_down_response", "enabled"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_http.test-gtm-http-monitor", "transparent", "enabled"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_http.test-gtm-http-monitor", "reverse", "enabled"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_http.test-gtm-http-monitor", "send", "GET /health\\r\\n"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_http.test-gtm-http-monitor", "receive", "healthy"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBigipGtmMonitorHttps_update(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckGtmMonitorHttpsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: TestGtmMonitorHttpsResource,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckGtmMonitorHttpsExists("/Common/test-gtm-https-monitor", true),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_https.test-gtm-https-monitor", "interval", "30"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_https.test-gtm-https-monitor", "cipherlist", "DEFAULT:+SHA:+3DES:+kEDH"),
+				),
+			},
+			{
+				Config: TestGtmMonitorHttpsResourceUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckGtmMonitorHttpsExists("/Common/test-gtm-https-monitor", true),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_https.test-gtm-https-monitor", "destination", "10.1.1.100:8443"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_https.test-gtm-https-monitor", "interval", "45"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_https.test-gtm-https-monitor", "cipherlist", "HIGH:!ADH:!MD5"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_https.test-gtm-https-monitor", "compatibility", "disabled"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBigipGtmMonitorPostgresql_update(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckGtmMonitorPostgresqlDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: TestGtmMonitorPostgresqlResource,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckGtmMonitorPostgresqlExists("/Common/test-gtm-postgresql-monitor", true),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_postgresql.test-gtm-postgresql-monitor", "database", "testdb"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_postgresql.test-gtm-postgresql-monitor", "debug", "no"),
+				),
+			},
+			{
+				Config: TestGtmMonitorPostgresqlResourceUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckGtmMonitorPostgresqlExists("/Common/test-gtm-postgresql-monitor", true),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_postgresql.test-gtm-postgresql-monitor", "destination", "192.168.1.50:5432"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_postgresql.test-gtm-postgresql-monitor", "database", "production"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_postgresql.test-gtm-postgresql-monitor", "username", "produser"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_postgresql.test-gtm-postgresql-monitor", "debug", "yes"),
+				),
+			},
+		},
+	})
+}
+
+// Import tests - verify resources can be imported correctly
+
+func TestAccBigipGtmMonitorHttp_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckGtmMonitorHttpDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: TestGtmMonitorHttpResource,
+			},
+			{
+				ResourceName:      "bigip_gtm_monitor_http.test-gtm-http-monitor",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBigipGtmMonitorHttps_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckGtmMonitorHttpsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: TestGtmMonitorHttpsResource,
+			},
+			{
+				ResourceName:      "bigip_gtm_monitor_https.test-gtm-https-monitor",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBigipGtmMonitorTcp_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckGtmMonitorTcpDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: TestGtmMonitorTcpResource,
+			},
+			{
+				ResourceName:      "bigip_gtm_monitor_tcp.test-gtm-tcp-monitor",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBigipGtmMonitorPostgresql_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckGtmMonitorPostgresqlDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: TestGtmMonitorPostgresqlResource,
+			},
+			{
+				ResourceName:      "bigip_gtm_monitor_postgresql.test-gtm-postgresql-monitor",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// Password is sensitive and won't be returned in read
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+func TestAccBigipGtmMonitorBigip_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckGtmMonitorBigipDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: TestGtmMonitorBigipResource,
+			},
+			{
+				ResourceName:      "bigip_gtm_monitor_bigip.test-gtm-bigip-monitor",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Minimal configuration tests - verify defaults work correctly
+
+func TestAccBigipGtmMonitorTcp_minimal(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckGtmMonitorTcpDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: TestGtmMonitorTcpResourceMinimal,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckGtmMonitorTcpExists("/Common/test-gtm-tcp-monitor-minimal", true),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_tcp.test-gtm-tcp-monitor-minimal", "name", "/Common/test-gtm-tcp-monitor-minimal"),
+					// Check defaults are applied
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_tcp.test-gtm-tcp-monitor-minimal", "defaults_from", "/Common/tcp"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_tcp.test-gtm-tcp-monitor-minimal", "destination", "*:*"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_tcp.test-gtm-tcp-monitor-minimal", "interval", "30"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_tcp.test-gtm-tcp-monitor-minimal", "timeout", "120"),
+				),
+			},
+		},
+	})
+}

--- a/bigip/resource_bigip_gtm_monitor_test.go
+++ b/bigip/resource_bigip_gtm_monitor_test.go
@@ -26,7 +26,7 @@ resource "bigip_gtm_monitor_http" "test-gtm-http-monitor" {
   ignore_down_response  = "disabled"
   transparent           = "disabled"
   reverse               = "disabled"
-  send                  = "GET /\\r\\n"
+  send                  = "GET /"
   receive              = "200 OK"
 }
 `
@@ -42,9 +42,9 @@ resource "bigip_gtm_monitor_https" "test-gtm-https-monitor" {
   ignore_down_response  = "disabled"
   transparent           = "disabled"
   reverse               = "disabled"
-  send                  = "GET /\\r\\n"
+  send                  = "GET /"
   receive              = "200 OK"
-  cipherlist           = "DEFAULT:+SHA:+3DES:+kEDH"
+  cipherlist           = "DEFAULT:!EXPORT"
   compatibility        = "enabled"
 }
 `
@@ -69,7 +69,7 @@ resource "bigip_gtm_monitor_postgresql" "test-gtm-postgresql-monitor" {
   defaults_from         = "/Common/postgresql"
   destination           = "*:5432"
   interval              = 30
-  timeout               = 120
+  timeout               = 91
   probe_timeout         = 5
   ignore_down_response  = "disabled"
   database              = "testdb"
@@ -161,7 +161,7 @@ func TestAccBigipGtmMonitorHttp_create(t *testing.T) {
 					resource.TestCheckResourceAttr("bigip_gtm_monitor_http.test-gtm-http-monitor", "defaults_from", "/Common/http"),
 					resource.TestCheckResourceAttr("bigip_gtm_monitor_http.test-gtm-http-monitor", "interval", "30"),
 					resource.TestCheckResourceAttr("bigip_gtm_monitor_http.test-gtm-http-monitor", "timeout", "120"),
-					resource.TestCheckResourceAttr("bigip_gtm_monitor_http.test-gtm-http-monitor", "send", "GET /\\r\\n"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_http.test-gtm-http-monitor", "send", "GET /"),
 				),
 			},
 		},
@@ -184,7 +184,7 @@ func TestAccBigipGtmMonitorHttps_create(t *testing.T) {
 					resource.TestCheckResourceAttr("bigip_gtm_monitor_https.test-gtm-https-monitor", "defaults_from", "/Common/https"),
 					resource.TestCheckResourceAttr("bigip_gtm_monitor_https.test-gtm-https-monitor", "interval", "30"),
 					resource.TestCheckResourceAttr("bigip_gtm_monitor_https.test-gtm-https-monitor", "timeout", "120"),
-					resource.TestCheckResourceAttr("bigip_gtm_monitor_https.test-gtm-https-monitor", "cipherlist", "DEFAULT:+SHA:+3DES:+kEDH"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_https.test-gtm-https-monitor", "cipherlist", "DEFAULT:!EXPORT"),
 				),
 			},
 		},
@@ -496,7 +496,7 @@ func TestAccBigipGtmMonitorHttps_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckGtmMonitorHttpsExists("/Common/test-gtm-https-monitor", true),
 					resource.TestCheckResourceAttr("bigip_gtm_monitor_https.test-gtm-https-monitor", "interval", "30"),
-					resource.TestCheckResourceAttr("bigip_gtm_monitor_https.test-gtm-https-monitor", "cipherlist", "DEFAULT:+SHA:+3DES:+kEDH"),
+					resource.TestCheckResourceAttr("bigip_gtm_monitor_https.test-gtm-https-monitor", "cipherlist", "DEFAULT:!EXPORT"),
 				),
 			},
 			{

--- a/bigip/resource_bigip_gtm_monitor_test.go
+++ b/bigip/resource_bigip_gtm_monitor_test.go
@@ -7,6 +7,7 @@ package bigip
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	bigip "github.com/f5devcentral/go-bigip"
@@ -281,6 +282,9 @@ func testCheckGtmMonitorHttpDestroyed(s *terraform.State) error {
 		name := rs.Primary.ID
 		monitor, err := client.GetGtmMonitor(name, "http")
 		if err != nil {
+			if strings.Contains(err.Error(), "not found") {
+				return nil
+			}
 			return err
 		}
 		if monitor != nil {
@@ -316,6 +320,9 @@ func testCheckGtmMonitorHttpsDestroyed(s *terraform.State) error {
 		name := rs.Primary.ID
 		monitor, err := client.GetGtmMonitor(name, "https")
 		if err != nil {
+			if strings.Contains(err.Error(), "not found") {
+				return nil
+			}
 			return err
 		}
 		if monitor != nil {
@@ -351,6 +358,9 @@ func testCheckGtmMonitorTcpDestroyed(s *terraform.State) error {
 		name := rs.Primary.ID
 		monitor, err := client.GetGtmMonitor(name, "tcp")
 		if err != nil {
+			if strings.Contains(err.Error(), "not found") {
+				return nil
+			}
 			return err
 		}
 		if monitor != nil {
@@ -386,6 +396,9 @@ func testCheckGtmMonitorPostgresqlDestroyed(s *terraform.State) error {
 		name := rs.Primary.ID
 		monitor, err := client.GetGtmMonitor(name, "postgresql")
 		if err != nil {
+			if strings.Contains(err.Error(), "not found") {
+				return nil
+			}
 			return err
 		}
 		if monitor != nil {
@@ -421,6 +434,9 @@ func testCheckGtmMonitorBigipDestroyed(s *terraform.State) error {
 		name := rs.Primary.ID
 		monitor, err := client.GetGtmMonitor(name, "bigip")
 		if err != nil {
+			if strings.Contains(err.Error(), "not found") {
+				return nil
+			}
 			return err
 		}
 		if monitor != nil {

--- a/bigip/resource_bigip_gtm_monitor_unit_test.go
+++ b/bigip/resource_bigip_gtm_monitor_unit_test.go
@@ -148,7 +148,7 @@ func TestResourceBigipGtmMonitorPostgresqlSchema(t *testing.T) {
 	}
 
 	// Test PostgreSQL-specific fields
-	postgresqlFields := []string{"database", "username", "password", "count", "debug"}
+	postgresqlFields := []string{"database", "username", "password", "probe_count", "debug"}
 	for _, field := range postgresqlFields {
 		if _, ok := resource.Schema[field]; !ok {
 			t.Errorf("Expected PostgreSQL-specific field '%s' to exist in schema", field)

--- a/bigip/resource_bigip_gtm_monitor_unit_test.go
+++ b/bigip/resource_bigip_gtm_monitor_unit_test.go
@@ -148,7 +148,7 @@ func TestResourceBigipGtmMonitorPostgresqlSchema(t *testing.T) {
 	}
 
 	// Test PostgreSQL-specific fields
-	postgresqlFields := []string{"database", "username", "password", "probe_count", "debug"}
+	postgresqlFields := []string{"database", "username", "password", "instance_count", "debug"}
 	for _, field := range postgresqlFields {
 		if _, ok := resource.Schema[field]; !ok {
 			t.Errorf("Expected PostgreSQL-specific field '%s' to exist in schema", field)

--- a/bigip/resource_bigip_gtm_monitor_unit_test.go
+++ b/bigip/resource_bigip_gtm_monitor_unit_test.go
@@ -96,7 +96,7 @@ func TestResourceBigipGtmMonitorHttpsSchema(t *testing.T) {
 
 	// Verify cipherlist default
 	if s, ok := resource.Schema["cipherlist"]; ok {
-		expectedDefault := "DEFAULT:+SHA:+3DES:+kEDH"
+		expectedDefault := "DEFAULT:!EXPORT"
 		if s.Default != expectedDefault {
 			t.Errorf("Expected cipherlist default to be '%s', got '%v'", expectedDefault, s.Default)
 		}
@@ -323,7 +323,7 @@ func TestResourceBigipGtmMonitorHttpDefaultSendString(t *testing.T) {
 	}
 
 	// HTTP monitor should have default send string
-	expectedDefault := "GET /\\r\\n"
+	expectedDefault := "GET /"
 	if sendSchema.Default != expectedDefault {
 		t.Errorf("Expected send default to be '%s', got '%v'", expectedDefault, sendSchema.Default)
 	}

--- a/bigip/resource_bigip_gtm_monitor_unit_test.go
+++ b/bigip/resource_bigip_gtm_monitor_unit_test.go
@@ -1,0 +1,472 @@
+/*
+Copyright 2019 F5 Networks Inc.
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+package bigip
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// Unit tests for GTM Monitor resources - no F5 BIG-IP connection required
+
+func TestResourceBigipGtmMonitorHttpSchema(t *testing.T) {
+	resource := resourceBigipGtmMonitorHttp()
+
+	// Verify schema exists
+	if resource.Schema == nil {
+		t.Fatal("Expected schema to be defined")
+	}
+
+	// Test required fields
+	requiredFields := []string{"name"}
+	for _, field := range requiredFields {
+		s, ok := resource.Schema[field]
+		if !ok {
+			t.Errorf("Expected field '%s' to exist in schema", field)
+		}
+		if !s.Required {
+			t.Errorf("Expected field '%s' to be required", field)
+		}
+	}
+
+	// Test optional fields with defaults
+	optionalWithDefaults := map[string]interface{}{
+		"defaults_from":        "/Common/http",
+		"destination":          "*:*",
+		"interval":             30,
+		"timeout":              120,
+		"probe_timeout":        5,
+		"ignore_down_response": "disabled",
+		"transparent":          "disabled",
+		"reverse":              "disabled",
+	}
+
+	for field, expectedDefault := range optionalWithDefaults {
+		s, ok := resource.Schema[field]
+		if !ok {
+			t.Errorf("Expected field '%s' to exist in schema", field)
+			continue
+		}
+		if s.Required {
+			t.Errorf("Expected field '%s' to be optional", field)
+		}
+		if s.Default != expectedDefault {
+			t.Errorf("Expected field '%s' default to be %v, got %v", field, expectedDefault, s.Default)
+		}
+	}
+
+	// Verify CRUD functions are defined
+	if resource.CreateContext == nil {
+		t.Error("Expected CreateContext to be defined")
+	}
+	if resource.ReadContext == nil {
+		t.Error("Expected ReadContext to be defined")
+	}
+	if resource.UpdateContext == nil {
+		t.Error("Expected UpdateContext to be defined")
+	}
+	if resource.DeleteContext == nil {
+		t.Error("Expected DeleteContext to be defined")
+	}
+
+	// Verify Importer is defined
+	if resource.Importer == nil {
+		t.Error("Expected Importer to be defined")
+	}
+}
+
+func TestResourceBigipGtmMonitorHttpsSchema(t *testing.T) {
+	resource := resourceBigipGtmMonitorHttps()
+
+	if resource.Schema == nil {
+		t.Fatal("Expected schema to be defined")
+	}
+
+	// Test HTTPS-specific fields
+	httpsFields := []string{"cert", "key", "cipherlist", "compatibility"}
+	for _, field := range httpsFields {
+		if _, ok := resource.Schema[field]; !ok {
+			t.Errorf("Expected HTTPS-specific field '%s' to exist in schema", field)
+		}
+	}
+
+	// Verify cipherlist default
+	if s, ok := resource.Schema["cipherlist"]; ok {
+		expectedDefault := "DEFAULT:+SHA:+3DES:+kEDH"
+		if s.Default != expectedDefault {
+			t.Errorf("Expected cipherlist default to be '%s', got '%v'", expectedDefault, s.Default)
+		}
+	}
+
+	// Verify compatibility default
+	if s, ok := resource.Schema["compatibility"]; ok {
+		expectedDefault := "enabled"
+		if s.Default != expectedDefault {
+			t.Errorf("Expected compatibility default to be '%s', got '%v'", expectedDefault, s.Default)
+		}
+	}
+}
+
+func TestResourceBigipGtmMonitorTcpSchema(t *testing.T) {
+	resource := resourceBigipGtmMonitorTcp()
+
+	if resource.Schema == nil {
+		t.Fatal("Expected schema to be defined")
+	}
+
+	// Verify send/receive are optional (not required)
+	optionalFields := []string{"send", "receive"}
+	for _, field := range optionalFields {
+		s, ok := resource.Schema[field]
+		if !ok {
+			t.Errorf("Expected field '%s' to exist in schema", field)
+			continue
+		}
+		if s.Required {
+			t.Errorf("Expected field '%s' to be optional for TCP monitors", field)
+		}
+	}
+
+	// Verify defaults_from default value
+	if s, ok := resource.Schema["defaults_from"]; ok {
+		expectedDefault := "/Common/tcp"
+		if s.Default != expectedDefault {
+			t.Errorf("Expected defaults_from default to be '%s', got '%v'", expectedDefault, s.Default)
+		}
+	}
+}
+
+func TestResourceBigipGtmMonitorPostgresqlSchema(t *testing.T) {
+	resource := resourceBigipGtmMonitorPostgresql()
+
+	if resource.Schema == nil {
+		t.Fatal("Expected schema to be defined")
+	}
+
+	// Test PostgreSQL-specific fields
+	postgresqlFields := []string{"database", "username", "password", "count", "debug"}
+	for _, field := range postgresqlFields {
+		if _, ok := resource.Schema[field]; !ok {
+			t.Errorf("Expected PostgreSQL-specific field '%s' to exist in schema", field)
+		}
+	}
+
+	// Verify password is marked as sensitive
+	if s, ok := resource.Schema["password"]; ok {
+		if !s.Sensitive {
+			t.Error("Expected password field to be marked as sensitive")
+		}
+	}
+
+	// Verify debug default
+	if s, ok := resource.Schema["debug"]; ok {
+		expectedDefault := "no"
+		if s.Default != expectedDefault {
+			t.Errorf("Expected debug default to be '%s', got '%v'", expectedDefault, s.Default)
+		}
+	}
+
+	// Verify defaults_from default value
+	if s, ok := resource.Schema["defaults_from"]; ok {
+		expectedDefault := "/Common/postgresql"
+		if s.Default != expectedDefault {
+			t.Errorf("Expected defaults_from default to be '%s', got '%v'", expectedDefault, s.Default)
+		}
+	}
+}
+
+func TestResourceBigipGtmMonitorBigipSchema(t *testing.T) {
+	resource := resourceBigipGtmMonitorBigip()
+
+	if resource.Schema == nil {
+		t.Fatal("Expected schema to be defined")
+	}
+
+	// Verify BIG-IP monitor does NOT have probe_timeout
+	if _, ok := resource.Schema["probe_timeout"]; ok {
+		t.Error("BIG-IP monitor should not have probe_timeout field")
+	}
+
+	// Verify BIG-IP monitor has aggregation_type
+	if _, ok := resource.Schema["aggregation_type"]; !ok {
+		t.Error("Expected BIG-IP monitor to have aggregation_type field")
+	}
+
+	// Verify aggregation_type default
+	if s, ok := resource.Schema["aggregation_type"]; ok {
+		expectedDefault := "none"
+		if s.Default != expectedDefault {
+			t.Errorf("Expected aggregation_type default to be '%s', got '%v'", expectedDefault, s.Default)
+		}
+	}
+
+	// Verify timeout default is 90 (different from other monitors)
+	if s, ok := resource.Schema["timeout"]; ok {
+		expectedDefault := 90
+		if s.Default != expectedDefault {
+			t.Errorf("Expected timeout default to be %d, got %v", expectedDefault, s.Default)
+		}
+	}
+
+	// Verify defaults_from default value
+	if s, ok := resource.Schema["defaults_from"]; ok {
+		expectedDefault := "/Common/bigip"
+		if s.Default != expectedDefault {
+			t.Errorf("Expected defaults_from default to be '%s', got '%v'", expectedDefault, s.Default)
+		}
+	}
+
+	// Verify BIG-IP monitor does NOT have send/receive
+	if _, ok := resource.Schema["send"]; ok {
+		t.Error("BIG-IP monitor should not have send field")
+	}
+	if _, ok := resource.Schema["receive"]; ok {
+		t.Error("BIG-IP monitor should not have receive field")
+	}
+}
+
+func TestResourceBigipGtmMonitorSchemaTypes(t *testing.T) {
+	// Test that all resources have correct schema types
+	resources := map[string]*schema.Resource{
+		"http":       resourceBigipGtmMonitorHttp(),
+		"https":      resourceBigipGtmMonitorHttps(),
+		"tcp":        resourceBigipGtmMonitorTcp(),
+		"postgresql": resourceBigipGtmMonitorPostgresql(),
+		"bigip":      resourceBigipGtmMonitorBigip(),
+	}
+
+	for monitorType, resource := range resources {
+		t.Run(monitorType, func(t *testing.T) {
+			// Verify string fields are TypeString
+			stringFields := []string{"name", "defaults_from", "destination"}
+			for _, field := range stringFields {
+				if s, ok := resource.Schema[field]; ok {
+					if s.Type != schema.TypeString {
+						t.Errorf("[%s] Expected field '%s' to be TypeString, got %v", monitorType, field, s.Type)
+					}
+				}
+			}
+
+			// Verify integer fields are TypeInt
+			intFields := []string{"interval", "timeout"}
+			for _, field := range intFields {
+				if s, ok := resource.Schema[field]; ok {
+					if s.Type != schema.TypeInt {
+						t.Errorf("[%s] Expected field '%s' to be TypeInt, got %v", monitorType, field, s.Type)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestResourceBigipGtmMonitorNameValidation(t *testing.T) {
+	resources := map[string]*schema.Resource{
+		"http":       resourceBigipGtmMonitorHttp(),
+		"https":      resourceBigipGtmMonitorHttps(),
+		"tcp":        resourceBigipGtmMonitorTcp(),
+		"postgresql": resourceBigipGtmMonitorPostgresql(),
+		"bigip":      resourceBigipGtmMonitorBigip(),
+	}
+
+	for monitorType, resource := range resources {
+		t.Run(monitorType, func(t *testing.T) {
+			nameSchema, ok := resource.Schema["name"]
+			if !ok {
+				t.Fatalf("[%s] Expected 'name' field to exist", monitorType)
+			}
+
+			// Verify name field has validation function
+			if nameSchema.ValidateFunc == nil {
+				t.Errorf("[%s] Expected 'name' field to have ValidateFunc", monitorType)
+			}
+
+			// Verify name is ForceNew (cannot be changed after creation)
+			if !nameSchema.ForceNew {
+				t.Errorf("[%s] Expected 'name' field to be ForceNew", monitorType)
+			}
+		})
+	}
+}
+
+func TestResourceBigipGtmMonitorDescriptions(t *testing.T) {
+	resources := map[string]*schema.Resource{
+		"http":       resourceBigipGtmMonitorHttp(),
+		"https":      resourceBigipGtmMonitorHttps(),
+		"tcp":        resourceBigipGtmMonitorTcp(),
+		"postgresql": resourceBigipGtmMonitorPostgresql(),
+		"bigip":      resourceBigipGtmMonitorBigip(),
+	}
+
+	for monitorType, resource := range resources {
+		t.Run(monitorType, func(t *testing.T) {
+			// Verify all fields have descriptions
+			for fieldName, fieldSchema := range resource.Schema {
+				if fieldSchema.Description == "" {
+					t.Errorf("[%s] Field '%s' missing description", monitorType, fieldName)
+				}
+			}
+		})
+	}
+}
+
+func TestResourceBigipGtmMonitorHttpDefaultSendString(t *testing.T) {
+	resource := resourceBigipGtmMonitorHttp()
+
+	sendSchema, ok := resource.Schema["send"]
+	if !ok {
+		t.Fatal("Expected 'send' field to exist")
+	}
+
+	// HTTP monitor should have default send string
+	expectedDefault := "GET /\\r\\n"
+	if sendSchema.Default != expectedDefault {
+		t.Errorf("Expected send default to be '%s', got '%v'", expectedDefault, sendSchema.Default)
+	}
+}
+
+func TestNormalizeGtmBigipDestination(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string returns default",
+			input:    "",
+			expected: "*:*",
+		},
+		{
+			name:     "wildcard without port gets port appended",
+			input:    "*",
+			expected: "*:*",
+		},
+		{
+			name:     "IP without port gets wildcard port appended",
+			input:    "10.1.1.100",
+			expected: "10.1.1.100:*",
+		},
+		{
+			name:     "already has port - no change",
+			input:    "*:*",
+			expected: "*:*",
+		},
+		{
+			name:     "IP with specific port - no change",
+			input:    "10.1.1.100:8080",
+			expected: "10.1.1.100:8080",
+		},
+		{
+			name:     "wildcard IP with specific port - no change",
+			input:    "*:5432",
+			expected: "*:5432",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeGtmBigipDestination(tt.input)
+			if result != tt.expected {
+				t.Errorf("normalizeGtmBigipDestination(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestValidateGtmBigipDestination(t *testing.T) {
+	tests := []struct {
+		name        string
+		destination string
+		expectError bool
+	}{
+		{
+			name:        "empty string is valid",
+			destination: "",
+			expectError: false,
+		},
+		{
+			name:        "all wildcards is valid",
+			destination: "*:*",
+			expectError: false,
+		},
+		{
+			name:        "wildcard IP with specific port is valid",
+			destination: "*:80",
+			expectError: false,
+		},
+		{
+			name:        "specific IP with specific port is valid",
+			destination: "10.1.1.50:80",
+			expectError: false,
+		},
+		{
+			name:        "specific IP with wildcard port is INVALID",
+			destination: "10.1.1.50:*",
+			expectError: true,
+		},
+		{
+			name:        "another specific IP with wildcard port is INVALID",
+			destination: "192.168.1.100:*",
+			expectError: true,
+		},
+		{
+			name:        "specific IP with port 443 is valid",
+			destination: "10.1.1.50:443",
+			expectError: false,
+		},
+		{
+			name:        "wildcard IP with port 5432 is valid",
+			destination: "*:5432",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateGtmBigipDestination(tt.destination)
+			if tt.expectError && err == nil {
+				t.Errorf("validateGtmBigipDestination(%q) expected error, got nil", tt.destination)
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("validateGtmBigipDestination(%q) unexpected error: %v", tt.destination, err)
+			}
+		})
+	}
+}
+
+func TestResourceBigipGtmMonitorIntervalTimeoutValidation(t *testing.T) {
+	// Verify timeout is always greater than interval in defaults
+	resources := map[string]*schema.Resource{
+		"http":       resourceBigipGtmMonitorHttp(),
+		"https":      resourceBigipGtmMonitorHttps(),
+		"tcp":        resourceBigipGtmMonitorTcp(),
+		"postgresql": resourceBigipGtmMonitorPostgresql(),
+		"bigip":      resourceBigipGtmMonitorBigip(),
+	}
+
+	for monitorType, resource := range resources {
+		t.Run(monitorType, func(t *testing.T) {
+			intervalSchema, okInterval := resource.Schema["interval"]
+			timeoutSchema, okTimeout := resource.Schema["timeout"]
+
+			if !okInterval || !okTimeout {
+				t.Fatalf("[%s] Expected both interval and timeout fields to exist", monitorType)
+			}
+
+			interval, okIntervalInt := intervalSchema.Default.(int)
+			timeout, okTimeoutInt := timeoutSchema.Default.(int)
+
+			if !okIntervalInt || !okTimeoutInt {
+				t.Fatalf("[%s] Expected interval and timeout defaults to be integers", monitorType)
+			}
+
+			if timeout <= interval {
+				t.Errorf("[%s] Expected timeout (%d) to be greater than interval (%d)", monitorType, timeout, interval)
+			}
+		})
+	}
+}

--- a/docs/guides/gtm_comprehensive_guide.md
+++ b/docs/guides/gtm_comprehensive_guide.md
@@ -76,7 +76,11 @@ GTM resources must be created in a specific order due to dependencies:
 | `bigip_gtm_server` | BIG-IP system or generic host server | ✅ Available |
 | `bigip_gtm_pool` | Collection of virtual servers for load balancing | ✅ Available |
 | `bigip_gtm_wideip` | DNS name that GTM resolves | ✅ Available |
-| `bigip_gtm_monitor` | Health monitors for GTM | ❌ Not Yet Implemented |
+| `bigip_gtm_monitor_http` | HTTP health monitor | ✅ Available |
+| `bigip_gtm_monitor_https` | HTTPS health monitor | ✅ Available |
+| `bigip_gtm_monitor_tcp` | TCP health monitor | ✅ Available |
+| `bigip_gtm_monitor_postgresql` | PostgreSQL health monitor | ✅ Available |
+| `bigip_gtm_monitor_bigip` | BIG-IP health monitor | ✅ Available |
 | `bigip_gtm_prober_pool` | Pool of probers for health checking | ❌ Not Yet Implemented |
 | `bigip_gtm_topology` | Topology records for geographic routing | ❌ Not Yet Implemented |
 

--- a/docs/resources/bigip_gtm_monitor_bigip.md
+++ b/docs/resources/bigip_gtm_monitor_bigip.md
@@ -1,0 +1,62 @@
+# bigip_gtm_monitor_bigip Resource
+
+Provides a BIG-IP GTM (Global Traffic Manager) BIG-IP Monitor resource. This resource allows you to configure and manage GTM BIG-IP health monitors on a BIG-IP system.
+
+## Description
+
+A GTM BIG-IP monitor is designed to monitor BIG-IP systems themselves within your GTM infrastructure. Unlike protocol-specific monitors (HTTP, TCP, etc.), the BIG-IP monitor collects health and performance data directly from BIG-IP devices, including metrics such as CPU usage, memory utilization, and throughput. This monitor type does not use `send`/`receive` strings or `probe_timeout` and instead focuses on aggregated system-level metrics.
+
+## Example Usage
+
+### Basic BIG-IP Monitor
+
+```hcl
+resource "bigip_gtm_monitor_bigip" "example" {
+  name = "/Common/my_bigip_monitor"
+}
+```
+
+### Full BIG-IP Monitor Configuration
+
+```hcl
+resource "bigip_gtm_monitor_bigip" "advanced" {
+  name                 = "/Common/my_bigip_monitor"
+  defaults_from        = "/Common/bigip"
+  destination          = "*:*"
+  interval             = 10
+  timeout              = 30
+  ignore_down_response = "disabled"
+  aggregation_type     = "average-nodes"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+### Required Arguments
+
+* `name` - (Required, String) The full path name of the GTM BIG-IP monitor (e.g., `/Common/my_bigip_monitor`). Forces new resource.
+
+### Optional Arguments
+
+* `defaults_from` - (Optional, String) Specifies the parent monitor from which this monitor inherits settings. Default: `/Common/bigip`.
+* `destination` - (Optional, String) Specifies the IP address and service port of the resource being monitored. Format: `ip:port`. Default: `*:*`. Note: when a specific IP address is provided, a specific port is also required (BIG-IP API constraint).
+* `interval` - (Optional, Integer) Specifies, in seconds, the frequency at which the system issues the monitor check. Default: `30`.
+* `timeout` - (Optional, Integer) Specifies the number of seconds the target has in which to respond to the monitor request. Default: `90`.
+* `ignore_down_response` - (Optional, String) Specifies whether the monitor ignores a down response from the system it is monitoring. Valid values: `enabled`, `disabled`. Default: `disabled`.
+* `aggregation_type` - (Optional, String) Specifies how the system combines the monitor information it collects for a pool of monitored resources. Default: `none`.
+
+## Attribute Reference
+
+In addition to the arguments listed above, the following attributes are exported:
+
+* `id` - The full path name of the GTM BIG-IP monitor.
+
+## Import
+
+GTM BIG-IP Monitor resources can be imported using the full path name:
+
+```bash
+terraform import bigip_gtm_monitor_bigip.example /Common/my_bigip_monitor
+```

--- a/docs/resources/bigip_gtm_monitor_bigip.md
+++ b/docs/resources/bigip_gtm_monitor_bigip.md
@@ -1,10 +1,17 @@
 # bigip_gtm_monitor_bigip Resource
 
-Provides a BIG-IP GTM (Global Traffic Manager) BIG-IP Monitor resource. This resource allows you to configure and manage GTM BIG-IP health monitors on a BIG-IP system.
+Provides a BIG-IP GTM (Global Traffic Manager) BIG-IP Monitor resource. This resource allows you to configure and manage GTM BIG-IP monitors on a BIG-IP system.
 
 ## Description
 
-A GTM BIG-IP monitor is designed to monitor BIG-IP systems themselves within your GTM infrastructure. Unlike protocol-specific monitors (HTTP, TCP, etc.), the BIG-IP monitor collects health and performance data directly from BIG-IP devices, including metrics such as CPU usage, memory utilization, and throughput. This monitor type does not use `send`/`receive` strings or `probe_timeout` and instead focuses on aggregated system-level metrics.
+A GTM BIG-IP monitor is both a health and performance monitor that acquires data captured through monitors managed by a BIG-IP Local Traffic Manager.
+
+You can monitor only the following components with a BIG-IP monitor:
+
+* Global Traffic Manager server
+* Global Traffic Manager virtual server
+* Local Traffic Manager server
+* Local Traffic Manager virtual server
 
 ## Example Usage
 
@@ -45,7 +52,7 @@ The following arguments are supported:
 * `interval` - (Optional, Integer) Specifies, in seconds, the frequency at which the system issues the monitor check. Default: `30`.
 * `timeout` - (Optional, Integer) Specifies the number of seconds the target has in which to respond to the monitor request. Default: `90`.
 * `ignore_down_response` - (Optional, String) Specifies whether the monitor ignores a down response from the system it is monitoring. Valid values: `enabled`, `disabled`. Default: `disabled`.
-* `aggregation_type` - (Optional, String) Specifies how the system combines the monitor information it collects for a pool of monitored resources. Default: `none`.
+* `aggregation_type` - (Optional, String) Specifies how the system combines the monitor information it collects for a pool of monitored resources. Valid values: `none`, `average-members`, `average-nodes`, `sum-members`, `sum-nodes`. Default: `none`.
 
 ## Attribute Reference
 

--- a/docs/resources/bigip_gtm_monitor_http.md
+++ b/docs/resources/bigip_gtm_monitor_http.md
@@ -52,7 +52,7 @@ The following arguments are supported:
 * `ignore_down_response` - (Optional, String) Specifies whether the monitor ignores a down response from the system it is monitoring. Valid values: `enabled`, `disabled`. Default: `disabled`.
 * `transparent` - (Optional, String) Specifies whether the monitor operates in transparent mode. Valid values: `enabled`, `disabled`. Default: `disabled`.
 * `reverse` - (Optional, String) Instructs the system to mark the target resource down when the test is successful. Valid values: `enabled`, `disabled`. Default: `disabled`.
-* `send` - (Optional, String) Specifies the text string that the monitor sends to the target object. Default: `GET /\r\n`.
+* `send` - (Optional, String) Specifies the text string that the monitor sends to the target object. Default: `GET /`.
 * `receive` - (Optional, String) Specifies the text string that the monitor looks for in the returned resource.
 
 ## Attribute Reference

--- a/docs/resources/bigip_gtm_monitor_http.md
+++ b/docs/resources/bigip_gtm_monitor_http.md
@@ -4,7 +4,7 @@ Provides a BIG-IP GTM (Global Traffic Manager) HTTP Monitor resource. This resou
 
 ## Description
 
-A GTM HTTP monitor verifies the availability and performance of HTTP services across your GTM infrastructure. The monitor sends HTTP requests to target resources and evaluates the responses to determine health status. HTTP monitors are commonly used to check web server availability and verify that expected content is being served.
+A GTM HTTP monitor verifies the HTTP service by attempting to receive specific content from a web page.
 
 ## Example Usage
 

--- a/docs/resources/bigip_gtm_monitor_http.md
+++ b/docs/resources/bigip_gtm_monitor_http.md
@@ -1,0 +1,70 @@
+# bigip_gtm_monitor_http Resource
+
+Provides a BIG-IP GTM (Global Traffic Manager) HTTP Monitor resource. This resource allows you to configure and manage GTM HTTP health monitors on a BIG-IP system.
+
+## Description
+
+A GTM HTTP monitor verifies the availability and performance of HTTP services across your GTM infrastructure. The monitor sends HTTP requests to target resources and evaluates the responses to determine health status. HTTP monitors are commonly used to check web server availability and verify that expected content is being served.
+
+## Example Usage
+
+### Basic HTTP Monitor
+
+```hcl
+resource "bigip_gtm_monitor_http" "example" {
+  name = "/Common/my_http_monitor"
+}
+```
+
+### Full HTTP Monitor Configuration
+
+```hcl
+resource "bigip_gtm_monitor_http" "advanced" {
+  name                 = "/Common/my_http_monitor"
+  defaults_from        = "/Common/http"
+  destination          = "*:80"
+  interval             = 10
+  timeout              = 60
+  probe_timeout        = 3
+  ignore_down_response = "disabled"
+  transparent          = "disabled"
+  reverse              = "disabled"
+  send                 = "GET /health\\r\\n"
+  receive              = "200 OK"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+### Required Arguments
+
+* `name` - (Required, String) The full path name of the GTM HTTP monitor (e.g., `/Common/my_http_monitor`). Forces new resource.
+
+### Optional Arguments
+
+* `defaults_from` - (Optional, String) Specifies the parent monitor from which this monitor inherits settings. Default: `/Common/http`.
+* `destination` - (Optional, String) Specifies the IP address and service port of the resource being monitored. Format: `ip:port`. Default: `*:*`.
+* `interval` - (Optional, Integer) Specifies, in seconds, the frequency at which the system issues the monitor check. Default: `30`.
+* `timeout` - (Optional, Integer) Specifies the number of seconds the target has in which to respond to the monitor request. Default: `120`.
+* `probe_timeout` - (Optional, Integer) Specifies the number of seconds after which the system times out the probe request. Default: `5`.
+* `ignore_down_response` - (Optional, String) Specifies whether the monitor ignores a down response from the system it is monitoring. Valid values: `enabled`, `disabled`. Default: `disabled`.
+* `transparent` - (Optional, String) Specifies whether the monitor operates in transparent mode. Valid values: `enabled`, `disabled`. Default: `disabled`.
+* `reverse` - (Optional, String) Instructs the system to mark the target resource down when the test is successful. Valid values: `enabled`, `disabled`. Default: `disabled`.
+* `send` - (Optional, String) Specifies the text string that the monitor sends to the target object. Default: `GET /\r\n`.
+* `receive` - (Optional, String) Specifies the text string that the monitor looks for in the returned resource.
+
+## Attribute Reference
+
+In addition to the arguments listed above, the following attributes are exported:
+
+* `id` - The full path name of the GTM HTTP monitor.
+
+## Import
+
+GTM HTTP Monitor resources can be imported using the full path name:
+
+```bash
+terraform import bigip_gtm_monitor_http.example /Common/my_http_monitor
+```

--- a/docs/resources/bigip_gtm_monitor_https.md
+++ b/docs/resources/bigip_gtm_monitor_https.md
@@ -4,7 +4,7 @@ Provides a BIG-IP GTM (Global Traffic Manager) HTTPS Monitor resource. This reso
 
 ## Description
 
-A GTM HTTPS monitor verifies the availability and performance of HTTPS (SSL/TLS) services across your GTM infrastructure. The monitor establishes secure connections to target resources and evaluates the responses to determine health status. HTTPS monitors support client certificate authentication and configurable cipher lists, making them suitable for monitoring secure web services.
+A GTM HTTPS monitor verifies the HTTPS service by attempting to receive specific content from a web page protected by Secure Socket Layer (SSL) security. HTTPS monitors support client certificate authentication and configurable cipher lists.
 
 ## Example Usage
 

--- a/docs/resources/bigip_gtm_monitor_https.md
+++ b/docs/resources/bigip_gtm_monitor_https.md
@@ -1,0 +1,80 @@
+# bigip_gtm_monitor_https Resource
+
+Provides a BIG-IP GTM (Global Traffic Manager) HTTPS Monitor resource. This resource allows you to configure and manage GTM HTTPS health monitors on a BIG-IP system.
+
+## Description
+
+A GTM HTTPS monitor verifies the availability and performance of HTTPS (SSL/TLS) services across your GTM infrastructure. The monitor establishes secure connections to target resources and evaluates the responses to determine health status. HTTPS monitors support client certificate authentication and configurable cipher lists, making them suitable for monitoring secure web services.
+
+## Example Usage
+
+### Basic HTTPS Monitor
+
+```hcl
+resource "bigip_gtm_monitor_https" "example" {
+  name = "/Common/my_https_monitor"
+}
+```
+
+### HTTPS Monitor with Client Certificate
+
+```hcl
+resource "bigip_gtm_monitor_https" "with_cert" {
+  name          = "/Common/my_https_monitor"
+  defaults_from = "/Common/https"
+  destination   = "*:443"
+  interval      = 10
+  timeout       = 60
+  probe_timeout = 3
+  send          = "GET /health\\r\\n"
+  receive       = "200 OK"
+  cert          = "/Common/my_client_cert"
+  key           = "/Common/my_client_key"
+  cipherlist    = "DEFAULT:+SHA:+3DES:+kEDH"
+  compatibility = "enabled"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+### Required Arguments
+
+* `name` - (Required, String) The full path name of the GTM HTTPS monitor (e.g., `/Common/my_https_monitor`). Forces new resource.
+
+### Optional Arguments
+
+#### General Settings
+
+* `defaults_from` - (Optional, String) Specifies the parent monitor from which this monitor inherits settings. Default: `/Common/https`.
+* `destination` - (Optional, String) Specifies the IP address and service port of the resource being monitored. Format: `ip:port`. Default: `*:*`.
+* `interval` - (Optional, Integer) Specifies, in seconds, the frequency at which the system issues the monitor check. Default: `30`.
+* `timeout` - (Optional, Integer) Specifies the number of seconds the target has in which to respond to the monitor request. Default: `120`.
+* `probe_timeout` - (Optional, Integer) Specifies the number of seconds after which the system times out the probe request. Default: `5`.
+* `ignore_down_response` - (Optional, String) Specifies whether the monitor ignores a down response from the system it is monitoring. Valid values: `enabled`, `disabled`. Default: `disabled`.
+* `transparent` - (Optional, String) Specifies whether the monitor operates in transparent mode. Valid values: `enabled`, `disabled`. Default: `disabled`.
+* `reverse` - (Optional, String) Instructs the system to mark the target resource down when the test is successful. Valid values: `enabled`, `disabled`. Default: `disabled`.
+* `send` - (Optional, String) Specifies the text string that the monitor sends to the target object. Default: `GET /\r\n`.
+* `receive` - (Optional, String) Specifies the text string that the monitor looks for in the returned resource.
+
+#### SSL Settings
+
+* `cert` - (Optional, String) Specifies a fully-qualified path for a client certificate that the monitor sends to the target SSL server.
+* `key` - (Optional, String) Specifies the key for the client certificate that the monitor sends to the target SSL server.
+* `cipherlist` - (Optional, String) Specifies the list of ciphers for this monitor. Default: `DEFAULT:+SHA:+3DES:+kEDH`.
+* `compatibility` - (Optional, String) Specifies the SSL version compatibility. Valid values: `enabled`, `disabled`. Default: `enabled`.
+
+## Attribute Reference
+
+In addition to the arguments listed above, the following attributes are exported:
+
+* `id` - The full path name of the GTM HTTPS monitor.
+
+## Import
+
+GTM HTTPS Monitor resources can be imported using the full path name:
+
+```bash
+terraform import bigip_gtm_monitor_https.example /Common/my_https_monitor
+```

--- a/docs/resources/bigip_gtm_monitor_https.md
+++ b/docs/resources/bigip_gtm_monitor_https.md
@@ -30,7 +30,6 @@ resource "bigip_gtm_monitor_https" "with_cert" {
   receive       = "200 OK"
   cert          = "/Common/my_client_cert"
   key           = "/Common/my_client_key"
-  cipherlist    = "DEFAULT:+SHA:+3DES:+kEDH"
   compatibility = "enabled"
 }
 ```

--- a/docs/resources/bigip_gtm_monitor_https.md
+++ b/docs/resources/bigip_gtm_monitor_https.md
@@ -54,14 +54,14 @@ The following arguments are supported:
 * `ignore_down_response` - (Optional, String) Specifies whether the monitor ignores a down response from the system it is monitoring. Valid values: `enabled`, `disabled`. Default: `disabled`.
 * `transparent` - (Optional, String) Specifies whether the monitor operates in transparent mode. Valid values: `enabled`, `disabled`. Default: `disabled`.
 * `reverse` - (Optional, String) Instructs the system to mark the target resource down when the test is successful. Valid values: `enabled`, `disabled`. Default: `disabled`.
-* `send` - (Optional, String) Specifies the text string that the monitor sends to the target object. Default: `GET /\r\n`.
+* `send` - (Optional, String) Specifies the text string that the monitor sends to the target object. Default: `GET /`.
 * `receive` - (Optional, String) Specifies the text string that the monitor looks for in the returned resource.
 
 #### SSL Settings
 
 * `cert` - (Optional, String) Specifies a fully-qualified path for a client certificate that the monitor sends to the target SSL server.
 * `key` - (Optional, String) Specifies the key for the client certificate that the monitor sends to the target SSL server.
-* `cipherlist` - (Optional, String) Specifies the list of ciphers for this monitor. Default: `DEFAULT:+SHA:+3DES:+kEDH`.
+* `cipherlist` - (Optional, String) Specifies the list of ciphers for this monitor. Default: `DEFAULT:!EXPORT`.
 * `compatibility` - (Optional, String) Specifies the SSL version compatibility. Valid values: `enabled`, `disabled`. Default: `enabled`.
 
 ## Attribute Reference

--- a/docs/resources/bigip_gtm_monitor_postgresql.md
+++ b/docs/resources/bigip_gtm_monitor_postgresql.md
@@ -50,7 +50,7 @@ The following arguments are supported:
 * `defaults_from` - (Optional, String) Specifies the parent monitor from which this monitor inherits settings. Default: `/Common/postgresql`.
 * `destination` - (Optional, String) Specifies the IP address and service port of the resource being monitored. Format: `ip:port`. Default: `*:*`.
 * `interval` - (Optional, Integer) Specifies, in seconds, the frequency at which the system issues the monitor check. Default: `30`.
-* `timeout` - (Optional, Integer) Specifies the number of seconds the target has in which to respond to the monitor request. Default: `120`.
+* `timeout` - (Optional, Integer) Specifies the number of seconds the target has in which to respond to the monitor request. Default: `91`.
 * `probe_timeout` - (Optional, Integer) Specifies the number of seconds after which the system times out the probe request. Default: `5`.
 * `ignore_down_response` - (Optional, String) Specifies whether the monitor ignores a down response from the system it is monitoring. Valid values: `enabled`, `disabled`. Default: `disabled`.
 

--- a/docs/resources/bigip_gtm_monitor_postgresql.md
+++ b/docs/resources/bigip_gtm_monitor_postgresql.md
@@ -1,0 +1,81 @@
+# bigip_gtm_monitor_postgresql Resource
+
+Provides a BIG-IP GTM (Global Traffic Manager) PostgreSQL Monitor resource. This resource allows you to configure and manage GTM PostgreSQL health monitors on a BIG-IP system.
+
+## Description
+
+A GTM PostgreSQL monitor verifies the availability and performance of PostgreSQL database services across your GTM infrastructure. The monitor connects to a PostgreSQL database with optional authentication and evaluates the response to determine health status. PostgreSQL monitors support database-specific fields including database name, username, password, and probe count configuration.
+
+## Example Usage
+
+### Basic PostgreSQL Monitor
+
+```hcl
+resource "bigip_gtm_monitor_postgresql" "example" {
+  name = "/Common/my_postgresql_monitor"
+}
+```
+
+### PostgreSQL Monitor with Authentication
+
+```hcl
+resource "bigip_gtm_monitor_postgresql" "advanced" {
+  name                 = "/Common/my_postgresql_monitor"
+  defaults_from        = "/Common/postgresql"
+  destination          = "*:5432"
+  interval             = 10
+  timeout              = 60
+  probe_timeout        = 3
+  ignore_down_response = "disabled"
+  database             = "mydb"
+  username             = "monitor_user"
+  password             = "monitor_pass"
+  receive              = "SELECT"
+  debug                = "no"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+### Required Arguments
+
+* `name` - (Required, String) The full path name of the GTM PostgreSQL monitor (e.g., `/Common/my_postgresql_monitor`). Forces new resource.
+
+### Optional Arguments
+
+#### General Settings
+
+* `defaults_from` - (Optional, String) Specifies the parent monitor from which this monitor inherits settings. Default: `/Common/postgresql`.
+* `destination` - (Optional, String) Specifies the IP address and service port of the resource being monitored. Format: `ip:port`. Default: `*:*`.
+* `interval` - (Optional, Integer) Specifies, in seconds, the frequency at which the system issues the monitor check. Default: `30`.
+* `timeout` - (Optional, Integer) Specifies the number of seconds the target has in which to respond to the monitor request. Default: `120`.
+* `probe_timeout` - (Optional, Integer) Specifies the number of seconds after which the system times out the probe request. Default: `5`.
+* `ignore_down_response` - (Optional, String) Specifies whether the monitor ignores a down response from the system it is monitoring. Valid values: `enabled`, `disabled`. Default: `disabled`.
+
+#### Database Settings
+
+* `database` - (Optional, String) Specifies the name of the database that the monitor tries to access.
+* `username` - (Optional, String) Specifies the user name if the monitored target requires authentication.
+* `password` - (Optional, String, Sensitive) Specifies the password if the monitored target requires authentication.
+* `receive` - (Optional, String) Specifies the text string that the monitor looks for in the returned resource.
+
+#### Probe Settings
+
+* `probe_count` - (Optional, String) Specifies the number of monitor probes after which the system times out.
+* `debug` - (Optional, String) Specifies whether the monitor sends error messages and additional information to a log file created and labeled specifically for this monitor. Valid values: `yes`, `no`. Default: `no`.
+
+## Attribute Reference
+
+In addition to the arguments listed above, the following attributes are exported:
+
+* `id` - The full path name of the GTM PostgreSQL monitor.
+
+## Import
+
+GTM PostgreSQL Monitor resources can be imported using the full path name:
+
+```bash
+terraform import bigip_gtm_monitor_postgresql.example /Common/my_postgresql_monitor
+```

--- a/docs/resources/bigip_gtm_monitor_postgresql.md
+++ b/docs/resources/bigip_gtm_monitor_postgresql.md
@@ -61,9 +61,9 @@ The following arguments are supported:
 * `password` - (Optional, String, Sensitive) Specifies the password if the monitored target requires authentication.
 * `receive` - (Optional, String) Specifies the text string that the monitor looks for in the returned resource.
 
-#### Probe Settings
+#### Connection Settings
 
-* `probe_count` - (Optional, String) Specifies the number of monitor probes after which the system times out.
+* `instance_count` - (Optional, String) Specifies the number of instances for which the system keeps a connection open. A value of `0` keeps the connection open for all instances. A value of `1` opens a new connection for each instance. Any other positive value keeps the connection open for that many instances.
 * `debug` - (Optional, String) Specifies whether the monitor sends error messages and additional information to a log file created and labeled specifically for this monitor. Valid values: `yes`, `no`. Default: `no`.
 
 ## Attribute Reference

--- a/docs/resources/bigip_gtm_monitor_postgresql.md
+++ b/docs/resources/bigip_gtm_monitor_postgresql.md
@@ -4,7 +4,7 @@ Provides a BIG-IP GTM (Global Traffic Manager) PostgreSQL Monitor resource. This
 
 ## Description
 
-A GTM PostgreSQL monitor verifies the availability and performance of PostgreSQL database services across your GTM infrastructure. The monitor connects to a PostgreSQL database with optional authentication and evaluates the response to determine health status. PostgreSQL monitors support database-specific fields including database name, username, password, and probe count configuration.
+A GTM PostgreSQL monitor verifies PostgreSQL database services by connecting to a database and optionally executing a query and evaluating the response. PostgreSQL monitors support database-specific configuration including database name, username, password, and instance count.
 
 ## Example Usage
 
@@ -63,7 +63,7 @@ The following arguments are supported:
 
 #### Connection Settings
 
-* `instance_count` - (Optional, String) Specifies the number of instances for which the system keeps a connection open. A value of `0` keeps the connection open for all instances. A value of `1` opens a new connection for each instance. Any other positive value keeps the connection open for that many instances.
+* `instance_count` - (Optional, String) Specifies the number of instances for which the system keeps a connection open. By default, when you assign instances of this monitor to a resource, the system keeps the connection to the database open. With this option you can assign multiple instances to the database while reducing the overhead that multiple open connections can cause. A value of `0` keeps the connection open for all instances. A value of `1` opens a new connection for each instance. Any other positive value keeps the connection open for that many instances.
 * `debug` - (Optional, String) Specifies whether the monitor sends error messages and additional information to a log file created and labeled specifically for this monitor. Valid values: `yes`, `no`. Default: `no`.
 
 ## Attribute Reference

--- a/docs/resources/bigip_gtm_monitor_tcp.md
+++ b/docs/resources/bigip_gtm_monitor_tcp.md
@@ -4,7 +4,7 @@ Provides a BIG-IP GTM (Global Traffic Manager) TCP Monitor resource. This resour
 
 ## Description
 
-A GTM TCP monitor verifies the availability of TCP-based services across your GTM infrastructure. The monitor establishes TCP connections to target resources and optionally sends a string and evaluates the response to determine health status. TCP monitors are commonly used to check the availability of services such as databases, mail servers, and other TCP-based applications.
+A GTM TCP monitor verifies the health of TCP-based services by establishing a connection to the target. It can optionally send a text string and evaluate the response for more specific health checks.
 
 ## Example Usage
 

--- a/docs/resources/bigip_gtm_monitor_tcp.md
+++ b/docs/resources/bigip_gtm_monitor_tcp.md
@@ -1,0 +1,70 @@
+# bigip_gtm_monitor_tcp Resource
+
+Provides a BIG-IP GTM (Global Traffic Manager) TCP Monitor resource. This resource allows you to configure and manage GTM TCP health monitors on a BIG-IP system.
+
+## Description
+
+A GTM TCP monitor verifies the availability of TCP-based services across your GTM infrastructure. The monitor establishes TCP connections to target resources and optionally sends a string and evaluates the response to determine health status. TCP monitors are commonly used to check the availability of services such as databases, mail servers, and other TCP-based applications.
+
+## Example Usage
+
+### Basic TCP Monitor
+
+```hcl
+resource "bigip_gtm_monitor_tcp" "example" {
+  name = "/Common/my_tcp_monitor"
+}
+```
+
+### TCP Monitor with Send/Receive Strings
+
+```hcl
+resource "bigip_gtm_monitor_tcp" "advanced" {
+  name                 = "/Common/my_tcp_monitor"
+  defaults_from        = "/Common/tcp"
+  destination          = "*:3306"
+  interval             = 10
+  timeout              = 60
+  probe_timeout        = 3
+  ignore_down_response = "disabled"
+  transparent          = "disabled"
+  reverse              = "disabled"
+  send                 = "ping"
+  receive              = "pong"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+### Required Arguments
+
+* `name` - (Required, String) The full path name of the GTM TCP monitor (e.g., `/Common/my_tcp_monitor`). Forces new resource.
+
+### Optional Arguments
+
+* `defaults_from` - (Optional, String) Specifies the parent monitor from which this monitor inherits settings. Default: `/Common/tcp`.
+* `destination` - (Optional, String) Specifies the IP address and service port of the resource being monitored. Format: `ip:port`. Default: `*:*`.
+* `interval` - (Optional, Integer) Specifies, in seconds, the frequency at which the system issues the monitor check. Default: `30`.
+* `timeout` - (Optional, Integer) Specifies the number of seconds the target has in which to respond to the monitor request. Default: `120`.
+* `probe_timeout` - (Optional, Integer) Specifies the number of seconds after which the system times out the probe request. Default: `5`.
+* `ignore_down_response` - (Optional, String) Specifies whether the monitor ignores a down response from the system it is monitoring. Valid values: `enabled`, `disabled`. Default: `disabled`.
+* `transparent` - (Optional, String) Specifies whether the monitor operates in transparent mode. Valid values: `enabled`, `disabled`. Default: `disabled`.
+* `reverse` - (Optional, String) Instructs the system to mark the target resource down when the test is successful. Valid values: `enabled`, `disabled`. Default: `disabled`.
+* `send` - (Optional, String) Specifies the text string that the monitor sends to the target object.
+* `receive` - (Optional, String) Specifies the text string that the monitor looks for in the returned resource.
+
+## Attribute Reference
+
+In addition to the arguments listed above, the following attributes are exported:
+
+* `id` - The full path name of the GTM TCP monitor.
+
+## Import
+
+GTM TCP Monitor resources can be imported using the full path name:
+
+```bash
+terraform import bigip_gtm_monitor_tcp.example /Common/my_tcp_monitor
+```

--- a/examples/bigip_gtm_monitor_bigip.tf
+++ b/examples/bigip_gtm_monitor_bigip.tf
@@ -1,0 +1,15 @@
+# Basic BIG-IP monitor with defaults
+resource "bigip_gtm_monitor_bigip" "basic" {
+  name = "/Common/my_bigip_monitor"
+}
+
+# BIG-IP monitor with custom settings
+resource "bigip_gtm_monitor_bigip" "custom" {
+  name                 = "/Common/my_custom_bigip_monitor"
+  defaults_from        = "/Common/bigip"
+  destination          = "*:*"
+  interval             = 10
+  timeout              = 30
+  ignore_down_response = "disabled"
+  aggregation_type     = "average-nodes"
+}

--- a/examples/bigip_gtm_monitor_http.tf
+++ b/examples/bigip_gtm_monitor_http.tf
@@ -1,0 +1,19 @@
+# Basic HTTP monitor with defaults
+resource "bigip_gtm_monitor_http" "basic" {
+  name = "/Common/my_http_monitor"
+}
+
+# HTTP monitor with custom settings
+resource "bigip_gtm_monitor_http" "custom" {
+  name                 = "/Common/my_custom_http_monitor"
+  defaults_from        = "/Common/http"
+  destination          = "*:80"
+  interval             = 10
+  timeout              = 60
+  probe_timeout        = 3
+  ignore_down_response = "disabled"
+  transparent          = "disabled"
+  reverse              = "disabled"
+  send                 = "GET /health\\r\\n"
+  receive              = "200 OK"
+}

--- a/examples/bigip_gtm_monitor_https.tf
+++ b/examples/bigip_gtm_monitor_https.tf
@@ -1,0 +1,22 @@
+# Basic HTTPS monitor with defaults
+resource "bigip_gtm_monitor_https" "basic" {
+  name = "/Common/my_https_monitor"
+}
+
+# HTTPS monitor with client certificate and custom settings
+resource "bigip_gtm_monitor_https" "with_cert" {
+  name                 = "/Common/my_secure_https_monitor"
+  defaults_from        = "/Common/https"
+  destination          = "*:443"
+  interval             = 10
+  timeout              = 60
+  probe_timeout        = 3
+  ignore_down_response = "disabled"
+  transparent          = "disabled"
+  reverse              = "disabled"
+  send                 = "GET /health\\r\\n"
+  receive              = "200 OK"
+  cert                 = "/Common/my_client_cert"
+  key                  = "/Common/my_client_key"
+  compatibility        = "enabled"
+}

--- a/examples/bigip_gtm_monitor_postgresql.tf
+++ b/examples/bigip_gtm_monitor_postgresql.tf
@@ -1,0 +1,20 @@
+# Basic PostgreSQL monitor with defaults
+resource "bigip_gtm_monitor_postgresql" "basic" {
+  name = "/Common/my_postgresql_monitor"
+}
+
+# PostgreSQL monitor with database authentication
+resource "bigip_gtm_monitor_postgresql" "with_auth" {
+  name                 = "/Common/my_pg_auth_monitor"
+  defaults_from        = "/Common/postgresql"
+  destination          = "*:5432"
+  interval             = 10
+  timeout              = 60
+  probe_timeout        = 3
+  ignore_down_response = "disabled"
+  database             = "mydb"
+  username             = "monitor_user"
+  password             = "monitor_pass"
+  receive              = "SELECT"
+  debug                = "no"
+}

--- a/examples/bigip_gtm_monitor_tcp.tf
+++ b/examples/bigip_gtm_monitor_tcp.tf
@@ -1,0 +1,19 @@
+# Basic TCP monitor with defaults
+resource "bigip_gtm_monitor_tcp" "basic" {
+  name = "/Common/my_tcp_monitor"
+}
+
+# TCP monitor with send/receive strings
+resource "bigip_gtm_monitor_tcp" "custom" {
+  name                 = "/Common/my_custom_tcp_monitor"
+  defaults_from        = "/Common/tcp"
+  destination          = "*:3306"
+  interval             = 10
+  timeout              = 60
+  probe_timeout        = 3
+  ignore_down_response = "disabled"
+  transparent          = "disabled"
+  reverse              = "disabled"
+  send                 = "ping"
+  receive              = "pong"
+}

--- a/vendor/github.com/f5devcentral/go-bigip/gtm.go
+++ b/vendor/github.com/f5devcentral/go-bigip/gtm.go
@@ -84,12 +84,32 @@ type Gtmmonitors struct {
 }
 
 type Gtmmonitor struct {
-	Name          string `json:"name,omitempty"`
-	Defaults_from string `json:"defaultsFrom,omitempty"`
-	Interval      int    `json:"interval,omitempty"`
-	Probe_timeout int    `json:"probeTimeout,omitempty"`
-	Recv          string `json:"recv,omitempty"`
-	Send          string `json:"send,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	FullPath             string `json:"fullPath,omitempty"`
+	Partition            string `json:"partition,omitempty"`
+	Defaults_from        string `json:"defaultsFrom,omitempty"`
+	Destination          string `json:"destination,omitempty"`
+	Interval             int    `json:"interval,omitempty"`
+	Timeout              int    `json:"timeout,omitempty"`
+	Probe_timeout        int    `json:"probeTimeout,omitempty"`
+	Ignore_down_response string `json:"ignoreDownResponse,omitempty"`
+	Transparent          string `json:"transparent,omitempty"`
+	Reverse              string `json:"reverse,omitempty"`
+	Recv                 string `json:"recv,omitempty"`
+	Send                 string `json:"send,omitempty"`
+	// HTTPS-specific fields
+	Cert          string `json:"cert,omitempty"`
+	Key           string `json:"key,omitempty"`
+	Cipherlist    string `json:"cipherlist,omitempty"`
+	Compatibility string `json:"compatibility,omitempty"`
+	// PostgreSQL-specific fields
+	Database string `json:"database,omitempty"`
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+	Count    string `json:"count,omitempty"`
+	Debug    string `json:"debug,omitempty"`
+	// BIG-IP monitor-specific fields
+	Aggregate_dynamic_ratios string `json:"aggregateDynamicRatios,omitempty"`
 }
 
 type Servers struct {
@@ -501,6 +521,34 @@ func (b *BigIP) ModifyGtmmonitor(*Gtmmonitor) error {
 
 func (b *BigIP) DeleteGtmmonitor(name string) error {
 	return b.delete(uriGtm, uriGtmmonitor, uriHttp, name)
+}
+
+// CreateGtmMonitor creates a GTM monitor of the specified type
+func (b *BigIP) CreateGtmMonitor(monitor *Gtmmonitor, monitorType string) error {
+	return b.post(monitor, uriGtm, uriGtmmonitor, monitorType)
+}
+
+// GetGtmMonitor retrieves a GTM monitor of the specified type
+func (b *BigIP) GetGtmMonitor(name string, monitorType string) (*Gtmmonitor, error) {
+	var monitor Gtmmonitor
+	err, ok := b.getForEntity(&monitor, uriGtm, uriGtmmonitor, monitorType, name)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+	return &monitor, nil
+}
+
+// ModifyGtmMonitor modifies a GTM monitor of the specified type
+func (b *BigIP) ModifyGtmMonitor(name string, monitor *Gtmmonitor, monitorType string) error {
+	return b.put(monitor, uriGtm, uriGtmmonitor, monitorType, name)
+}
+
+// DeleteGtmMonitor deletes a GTM monitor of the specified type
+func (b *BigIP) DeleteGtmMonitor(name string, monitorType string) error {
+	return b.delete(uriGtm, uriGtmmonitor, monitorType, name)
 }
 
 func (b *BigIP) CreateGtmserver(p *Server) error {

--- a/vendor/github.com/f5devcentral/go-bigip/gtm.go
+++ b/vendor/github.com/f5devcentral/go-bigip/gtm.go
@@ -493,36 +493,6 @@ type GtmPoolMembers struct {
 	Ratio                     int    `json:"ratio,omitempty"`
 }
 
-func (b *BigIP) Gtmmonitors() (*Gtmmonitor, error) {
-	var gtmmonitor Gtmmonitor
-	err, _ := b.getForEntity(&gtmmonitor, uriGtm, uriGtmmonitor, uriHttp)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return &gtmmonitor, nil
-}
-func (b *BigIP) CreateGtmmonitor(name, defaults_from string, interval, probeTimeout int, recv, send string) error {
-	config := &Gtmmonitor{
-		Name:          name,
-		Defaults_from: defaults_from,
-		Interval:      interval,
-		Probe_timeout: probeTimeout,
-		Recv:          recv,
-		Send:          send,
-	}
-	return b.post(config, uriGtm, uriGtmmonitor, uriHttp)
-}
-
-func (b *BigIP) ModifyGtmmonitor(*Gtmmonitor) error {
-	return b.patch(uriGtm, uriGtmmonitor, uriHttp)
-}
-
-func (b *BigIP) DeleteGtmmonitor(name string) error {
-	return b.delete(uriGtm, uriGtmmonitor, uriHttp, name)
-}
-
 // CreateGtmMonitor creates a GTM monitor of the specified type
 func (b *BigIP) CreateGtmMonitor(monitor *Gtmmonitor, monitorType string) error {
 	return b.post(monitor, uriGtm, uriGtmmonitor, monitorType)


### PR DESCRIPTION
Add GTM (Global Traffic Manager) monitor resources support to the terraform-provider-bigip:

New Resources:
- bigip_gtm_monitor_http
- bigip_gtm_monitor_https
- bigip_gtm_monitor_tcp
- bigip_gtm_monitor_postgresql
- bigip_gtm_monitor_bigip

Features:
- Full CRUD operations for all GTM monitor resources

Documentation:
- Added resource documentation for all GTM monitor resources
- Added example configurations

Tests:
- Added unit tests for all GTM monitor resources
- Added acceptance tests for GTM monitor functionality