### PR TITLE
feat: Add metadata support for Virtual Servers and Pools

### DIFF
--- a/bigip/resource_bigip_ltm_pool.go
+++ b/bigip/resource_bigip_ltm_pool.go
@@ -93,6 +93,21 @@ func resourceBigipLtmPool() *schema.Resource {
 				Computed:    true,
 				Description: "Specifies the number of times the system tries to contact a new pool member after a passive failure.",
 			},
+			"metadata": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return d.Get("ignore_metadata").(bool)
+				},
+				Description: "Metadata key/value pairs for the pool.",
+			},
+			"ignore_metadata": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Set true to ignore metadata drift and skip sending metadata in create/update requests.",
+			},
 		},
 	}
 }
@@ -125,6 +140,7 @@ func resourceBigipLtmPoolCreate(ctx context.Context, d *schema.ResourceData, met
 			log.Printf("[ERROR]Sending Telemetry data failed:%v", err)
 		}
 	}
+
 	return resourceBigipLtmPoolUpdate(ctx, d, meta)
 }
 
@@ -152,6 +168,11 @@ func resourceBigipLtmPoolRead(ctx context.Context, d *schema.ResourceData, meta 
 	_ = d.Set("description", pool.Description)
 	monitors := strings.Split(strings.TrimSpace(pool.Monitor), " and ")
 	_ = d.Set("monitors", makeStringSet(&monitors))
+
+	if !d.Get("ignore_metadata").(bool) {
+		_ = d.Set("metadata", bigipMetadataToTfMetadata(pool.Metadata))
+	}
+
 	return nil
 }
 
@@ -191,6 +212,13 @@ func resourceBigipLtmPoolUpdate(ctx context.Context, d *schema.ResourceData, met
 		ReselectTries:     d.Get("reselect_tries").(int),
 		Monitor:           strings.Join(monitors, " and "),
 	}
+	if !d.Get("ignore_metadata").(bool) {
+		metadata, err := tfMetadataToBigipMetadata(d.Get("metadata").(map[string]interface{}))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		pool.Metadata = metadata
+	}
 	err := client.ModifyPool(name, pool)
 	if err != nil {
 		log.Printf("[ERROR] Unable to Modify Pool   (%s) (%v) ", name, err)
@@ -200,6 +228,7 @@ func resourceBigipLtmPoolUpdate(ctx context.Context, d *schema.ResourceData, met
 		}
 		return diag.FromErr(err)
 	}
+
 	return resourceBigipLtmPoolRead(ctx, d, meta)
 }
 func resourceBigipLtmPoolDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/bigip/resource_bigip_ltm_virtual_server.go
+++ b/bigip/resource_bigip_ltm_virtual_server.go
@@ -255,6 +255,21 @@ func resourceBigipLtmVirtualServer() *schema.Resource {
 				Computed:    true,
 				Description: "Applies the specified AFM policy to the virtual in an enforcing way,when creating a new virtual, if this parameter is not specified, the enforced is disabled.this should be in full path ex: `/Common/afm-test-policy`",
 			},
+			"metadata": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return d.Get("ignore_metadata").(bool)
+				},
+				Description: "Metadata key/value pairs for the virtual server.",
+			},
+			"ignore_metadata": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Set true to ignore metadata drift and skip sending metadata in create/update requests.",
+			},
 		},
 	}
 }
@@ -291,8 +306,11 @@ func resourceBigipLtmVirtualServerCreate(ctx context.Context, d *schema.Resource
 	pss := &bigip.VirtualServer{
 		Name: name,
 	}
-	config := getVirtualServerConfig(d, pss)
-	err := client.CreateVirtualServer(config)
+	config, err := getVirtualServerConfig(d, pss)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = client.CreateVirtualServer(config)
 	if err != nil {
 		log.Printf("[ERROR] Unable to Create Virtual Server  (%s) (%v)", name, err)
 		return diag.FromErr(err)
@@ -317,6 +335,7 @@ func resourceBigipLtmVirtualServerCreate(ctx context.Context, d *schema.Resource
 			log.Printf("[ERROR]Sending Telemetry data failed:%v", err)
 		}
 	}
+
 	return resourceBigipLtmVirtualServerRead(ctx, d, meta)
 }
 
@@ -429,6 +448,9 @@ func resourceBigipLtmVirtualServerRead(ctx context.Context, d *schema.ResourceDa
 	_ = d.Set("translate_address", vs.TranslateAddress)
 	_ = d.Set("translate_port", vs.TranslatePort)
 	_ = d.Set("firewall_enforced_policy", vs.FwEnforcedPolicy)
+	if !d.Get("ignore_metadata").(bool) {
+		_ = d.Set("metadata", bigipMetadataToTfMetadata(vs.Metadata))
+	}
 
 	if len(vs.PersistenceProfiles) > 0 {
 		default_persistence := fmt.Sprintf("/%s/%s", vs.PersistenceProfiles[0].Partition, vs.PersistenceProfiles[0].Name)
@@ -485,11 +507,15 @@ func resourceBigipLtmVirtualServerUpdate(ctx context.Context, d *schema.Resource
 		Name: name,
 	}
 	log.Println("[INFO] Updating virtual server " + name)
-	config := getVirtualServerConfig(d, pss)
-	err := client.ModifyVirtualServer(name, config)
+	config, err := getVirtualServerConfig(d, pss)
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	err = client.ModifyVirtualServer(name, config)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	return resourceBigipLtmVirtualServerRead(ctx, d, meta)
 }
 
@@ -508,7 +534,7 @@ func resourceBigipLtmVirtualServerDelete(ctx context.Context, d *schema.Resource
 	return nil
 }
 
-func getVirtualServerConfig(d *schema.ResourceData, config *bigip.VirtualServer) *bigip.VirtualServer {
+func getVirtualServerConfig(d *schema.ResourceData, config *bigip.VirtualServer) (*bigip.VirtualServer, error) {
 	ltmVirtualServerAttrDefaults(d)
 	port := d.Get("port").(int)
 	mask := d.Get("mask").(string)
@@ -616,5 +642,12 @@ func getVirtualServerConfig(d *schema.ResourceData, config *bigip.VirtualServer)
 	if d.Get("state").(string) == "enabled" {
 		config.Enabled = true
 	}
-	return config
+	if !d.Get("ignore_metadata").(bool) {
+		metadata, err := tfMetadataToBigipMetadata(d.Get("metadata").(map[string]interface{}))
+		if err != nil {
+			return nil, err
+		}
+		config.Metadata = metadata
+	}
+	return config, nil
 }

--- a/bigip/resource_bigip_metadata_helpers.go
+++ b/bigip/resource_bigip_metadata_helpers.go
@@ -1,0 +1,47 @@
+package bigip
+
+import (
+	"fmt"
+	"sort"
+
+	bigip "github.com/f5devcentral/go-bigip"
+)
+
+func tfMetadataToBigipMetadata(tf map[string]interface{}) ([]bigip.ResourceMetadata, error) {
+	if tf == nil {
+		return nil, nil
+	}
+
+	keys := make([]string, 0, len(tf))
+	for k := range tf {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	metadata := make([]bigip.ResourceMetadata, 0, len(tf))
+	for _, k := range keys {
+		v := tf[k]
+		s, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("metadata value for key %q must be a string", k)
+		}
+		metadata = append(metadata, bigip.ResourceMetadata{
+			Name:    k,
+			Value:   s,
+			Persist: "true",
+		})
+	}
+
+	return metadata, nil
+}
+
+func bigipMetadataToTfMetadata(metadata []bigip.ResourceMetadata) map[string]string {
+	tf := make(map[string]string, len(metadata))
+	for _, m := range metadata {
+		if m.Name == "" {
+			continue
+		}
+		tf[m.Name] = m.Value
+	}
+	return tf
+}

--- a/bigip/resource_bigip_metadata_helpers_test.go
+++ b/bigip/resource_bigip_metadata_helpers_test.go
@@ -1,0 +1,58 @@
+package bigip
+
+import (
+	"reflect"
+	"testing"
+
+	bigip "github.com/f5devcentral/go-bigip"
+)
+
+func TestTfMetadataToBigipMetadata(t *testing.T) {
+	input := map[string]interface{}{
+		"owner":       "terraform",
+		"environment": "dev",
+	}
+
+	got, err := tfMetadataToBigipMetadata(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []bigip.ResourceMetadata{
+		{Name: "environment", Value: "dev", Persist: "true"},
+		{Name: "owner", Value: "terraform", Persist: "true"},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("metadata mismatch\nwant: %#v\ngot:  %#v", want, got)
+	}
+}
+
+func TestTfMetadataToBigipMetadataRejectsNonString(t *testing.T) {
+	input := map[string]interface{}{
+		"count": 1,
+	}
+
+	_, err := tfMetadataToBigipMetadata(input)
+	if err == nil {
+		t.Fatal("expected error for non-string metadata value")
+	}
+}
+
+func TestBigipMetadataToTfMetadata(t *testing.T) {
+	input := []bigip.ResourceMetadata{
+		{Name: "environment", Value: "dev", Persist: "true"},
+		{Name: "owner", Value: "terraform", Persist: "true"},
+		{Name: "", Value: "skip", Persist: "true"},
+	}
+
+	got := bigipMetadataToTfMetadata(input)
+	want := map[string]string{
+		"environment": "dev",
+		"owner":       "terraform",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("metadata map mismatch\nwant: %#v\ngot:  %#v", want, got)
+	}
+}

--- a/docs/resources/bigip_ltm_pool.md
+++ b/docs/resources/bigip_ltm_pool.md
@@ -25,8 +25,13 @@ resource "bigip_ltm_pool" "pool" {
   load_balancing_mode    = "round-robin"
   minimum_active_members = 1
   monitors               = [bigip_ltm_monitor.monitor.name]
+  ignore_metadata        = false
+  metadata = {
+    environment = "dev"
+    owner       = "terraform"
+  }
 }
-```      
+```
 
 ## Argument Reference
 
@@ -34,7 +39,7 @@ resource "bigip_ltm_pool" "pool" {
 
 * `monitors` - (Optional,type `list`) List of monitor names to associate with the pool
 
-* `description` - (Optional,type `string`) Specifies descriptive text that identifies the pool. 
+* `description` - (Optional,type `string`) Specifies descriptive text that identifies the pool.
 
 * `allow_nat` - (Optional,type `string`) Specifies whether NATs are automatically enabled or disabled for any connections using this pool, [ Default : `yes`, Possible Values `yes` or `no`].
 
@@ -49,6 +54,10 @@ resource "bigip_ltm_pool" "pool" {
 * `service_down_action` - (Optional, type `string`) Specifies how the system should respond when the target pool member becomes unavailable. The default is `None`, Possible values: `[none, reset, reselect, drop]`.
 
 * `reselect_tries` - (Optional, type `int`) Specifies the number of times the system tries to contact a new pool member after a passive failure.
+
+* `metadata` - (Optional, type `map(string)`) Metadata key/value pairs to apply to the pool.
+
+* `ignore_metadata` - (Optional, type `bool`) Defaults to `true`. When `true`, metadata drift on BIG-IP is ignored and metadata is not sent in create/update requests.
 
 ## Importing
 An existing pool can be imported into this resource by supplying pool Name in `full path` as `id`.

--- a/docs/resources/bigip_ltm_virtual_server.md
+++ b/docs/resources/bigip_ltm_virtual_server.md
@@ -24,6 +24,11 @@ resource "bigip_ltm_virtual_server" "http" {
   destination = "10.12.12.12"
   port        = 80
   pool        = "/Common/the-default-pool"
+  ignore_metadata = false
+  metadata = {
+    environment = "dev"
+    owner       = "terraform"
+  }
 }
 
 # A Virtual server with SSL enabled
@@ -51,7 +56,7 @@ resource "bigip_ltm_virtual_server" "https" {
   source_address_translation = "automap"
 }
 
-```      
+```
 
 ## Argument Reference
 
@@ -104,6 +109,10 @@ By default it is `false` i.e vlanDisabled on specified vlans, if we want enable 
 * `source_port` - (Optional,type `string`) Specifies whether the system preserves the source port of the connection. The default is `preserve`.
 
 * `firewall_enforced_policy` - (Optional,type `string`) Applies the specified AFM policy to the virtual in an enforcing way,when creating a new virtual, if this parameter is not specified, the enforced is disabled.This should be in full path ex: `/Common/afm-test-policy`.
+
+* `metadata` - (Optional, type `map(string)`) Metadata key/value pairs to apply to the virtual server.
+
+* `ignore_metadata` - (Optional, type `bool`) Defaults to `true`. When `true`, metadata drift on BIG-IP is ignored and metadata is not sent in create/update requests.
 
 ## Importing
 An existing virtual-server can be imported into this resource by supplying virtual-server Name in `full path` as `id`.

--- a/examples/bigip_ltm_virtual_server.tf
+++ b/examples/bigip_ltm_virtual_server.tf
@@ -18,6 +18,11 @@ resource "bigip_ltm_pool" "vs_tc1" {
   monitors            = [bigip_ltm_monitor.vs_tc1.name]
   allow_snat          = "yes"
   allow_nat           = "yes"
+  ignore_metadata     = false
+  metadata = {
+    environment = "dev"
+    owner       = "terraform"
+  }
 }
 
 resource "bigip_ltm_pool_attachment" "vs_tc1" {
@@ -36,6 +41,11 @@ resource "bigip_ltm_virtual_server" "vs_tc1" {
   destination                = "100.1.1.100"
   port                       = 80
   source_address_translation = "automap"
+  ignore_metadata            = false
+  metadata = {
+    environment = "dev"
+    owner       = "terraform"
+  }
 }
 
 resource "bigip_ltm_virtual_server" "vs_tc2" {

--- a/vendor/github.com/f5devcentral/go-bigip/ltm.go
+++ b/vendor/github.com/f5devcentral/go-bigip/ltm.go
@@ -272,6 +272,13 @@ type Pools struct {
 	Pools []Pool `json:"items"`
 }
 
+// ResourceMetadata contains metadata key/value entries associated with LTM objects.
+type ResourceMetadata struct {
+	Name    string `json:"name,omitempty"`
+	Persist string `json:"persist,omitempty"`
+	Value   string `json:"value,omitempty"`
+}
+
 // Pool contains information about each pool. You can use all of these
 // fields when modifying a pool.
 type Pool struct {
@@ -299,6 +306,7 @@ type Pool struct {
 	ReselectTries          int    `json:"reselectTries"`
 	ServiceDownAction      string `json:"serviceDownAction,omitempty"`
 	SlowRampTime           int    `json:"slowRampTime"`
+	Metadata               []ResourceMetadata `json:"metadata,omitempty"`
 }
 
 // Pool Members contains a list of pool members within a pool on the BIG-IP system.
@@ -377,9 +385,10 @@ type poolDTO struct {
 	QueueDepthLimit        int    `json:"queueDepthLimit,omitempty"`
 	QueueOnConnectionLimit string `json:"queueOnConnectionLimit,omitempty"`
 	QueueTimeLimit         int    `json:"queueTimeLimit,omitempty"`
-	ReselectTries          int    `json:"reselectTries"`
-	ServiceDownAction      string `json:"serviceDownAction,omitempty"`
-	SlowRampTime           int    `json:"slowRampTime"`
+	ReselectTries          int                `json:"reselectTries"`
+	ServiceDownAction      string             `json:"serviceDownAction,omitempty"`
+	SlowRampTime           int                `json:"slowRampTime"`
+	Metadata               []ResourceMetadata `json:"metadata,omitempty"`
 }
 
 func (p *Pool) MarshalJSON() ([]byte, error) {
@@ -589,6 +598,7 @@ type VirtualServer struct {
 	PersistenceProfiles        []Profile `json:"persist"`
 	Profiles                   []Profile `json:"profiles,omitempty"`
 	Policies                   []string  `json:"policies"`
+	Metadata                   []ResourceMetadata `json:"metadata,omitempty"`
 }
 
 // VirtualAddresses contains a list of all virtual addresses on the BIG-IP system.


### PR DESCRIPTION
Adds metadata support for Pools and Virtual Servers.

follows the same ignore metadata pattern as the code for the AS3 templates does.

fixes #1147
