### PR TITLE
fix: refresh ltm_node state from BIG-IP to detect drift (#1153)

### DIFF
--- a/bigip/resource_bigip_ltm_node.go
+++ b/bigip/resource_bigip_ltm_node.go
@@ -227,6 +227,12 @@ func resourceBigipLtmNodeRead(ctx context.Context, d *schema.ResourceData, meta 
 	} else {
 		_ = d.Set("session", "user-disabled")
 	}
+	// Only user-down is an admin "forced offline" state; collapse monitor-driven runtime values (up/down/checking/unchecked/fqdn-*) to user-up to avoid spurious diffs.
+	if node.State == "user-down" {
+		_ = d.Set("state", "user-down")
+	} else {
+		_ = d.Set("state", "user-up")
+	}
 	_ = d.Set("connection_limit", node.ConnectionLimit)
 	_ = d.Set("description", node.Description)
 	_ = d.Set("dynamic_ratio", node.DynamicRatio)

--- a/bigip/resource_bigip_ltm_node_test.go
+++ b/bigip/resource_bigip_ltm_node_test.go
@@ -144,6 +144,51 @@ func TestAccBigipLtmNode_FqdnCreate(t *testing.T) {
 		},
 	})
 }
+
+// Verifies the Read function refreshes node.State from the device, so a
+// transition to user-down (e.g. admin force-offline) is observable in
+// Terraform state. Regression guard for issue #1153.
+func TestAccBigipLtmNode_StateRefresh(t *testing.T) {
+	t.Parallel()
+	instName := "test-node-state-refresh"
+	nodeName := fmt.Sprintf("/%s/%s", TestPartition, instName)
+	resFullName := fmt.Sprintf("%s.%s", resNodeName, instName)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckNodesDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testaccbigipltmNodeStateConfig(instName, "user-up"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckNodeExists(nodeName),
+					resource.TestCheckResourceAttr(resFullName, "state", "user-up"),
+					resource.TestCheckResourceAttr(resFullName, "session", "user-enabled"),
+				),
+			},
+			{
+				Config: testaccbigipltmNodeStateConfig(instName, "user-down"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckNodeExists(nodeName),
+					resource.TestCheckResourceAttr(resFullName, "state", "user-down"),
+				),
+			},
+		},
+	})
+}
+
+func testaccbigipltmNodeStateConfig(instName, state string) string {
+	return fmt.Sprintf(`
+resource "bigip_ltm_node" "%[1]s" {
+  name    = "/Common/%[1]s"
+  address = "192.168.100.101"
+  state   = "%[2]s"
+}
+`, instName, state)
+}
+
 func TestAccBigipLtmNodeUpdateMonitor(t *testing.T) {
 	t.Parallel()
 	var instName = "test-node-monitor"


### PR DESCRIPTION
_See my alternative fix in #1157 that I much prefer!_

## Summary

- Fixes [#1153](https://github.com/F5Networks/terraform-provider-bigip/issues/1153). `resourceBigipLtmNodeRead` reads `node.Session` back into Terraform state but never reads `node.State`, so when a node is manually force-offlined on the device (`state=user-down`), Terraform keeps whatever was last applied (e.g. `user-up`) and reports no drift.
- Mirrors the existing `session` normalization pattern: only `user-down` is treated as the admin "forced offline" state; everything else (monitor-driven runtime values like `up` / `down` / `checking` / `unchecked` / `fqdn-*`) collapses to `user-up`. This catches the drift case while avoiding spurious diffs when the monitor is mid-cycle.
- Adds `TestAccBigipLtmNode_StateRefresh` — a two-step acceptance test that creates a node with `state = "user-up"`, updates it to `state = "user-down"`, and asserts Terraform state tracks the change after Read.

## Test plan

- [ ] `make test` passes (unit tests + compile)
- [ ] `TF_ACC=1 go test ./bigip/ -run TestAccBigipLtmNode_StateRefresh -timeout=10m -v` passes against a real BIG-IP
- [ ] On a BIG-IP device, manually force a node offline via the UI after `terraform apply`; rerun `terraform plan` and confirm the drift is now detected (was: no changes; now: shows `state` returning to configured value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)