### PR TITLE
fix: refresh ltm_pool_attachment state from BIG-IP to detect drift (#1116)

### DIFF
--- a/bigip/resource_bigip_ltm_pool_attachment.go
+++ b/bigip/resource_bigip_ltm_pool_attachment.go
@@ -334,6 +334,15 @@ func resourceBigipLtmPoolAttachmentRead(ctx context.Context, d *schema.ResourceD
 				_ = d.Set("connection_rate_limit", node.RateLimit)
 				_ = d.Set("dynamic_ratio", node.DynamicRatio)
 				_ = d.Set("monitor", node.Monitor)
+				// Inverse of the Update mapping: state=user-down -> forced_offline; session=user-disabled (with state=user-up) -> disabled; everything else (including monitor-driven session/state) -> enabled.
+				switch {
+				case node.State == "user-down":
+					_ = d.Set("state", "forced_offline")
+				case node.Session == "user-disabled":
+					_ = d.Set("state", "disabled")
+				default:
+					_ = d.Set("state", "enabled")
+				}
 				found = true
 				break
 			}
@@ -349,6 +358,15 @@ func resourceBigipLtmPoolAttachmentRead(ctx context.Context, d *schema.ResourceD
 				_ = d.Set("connection_rate_limit", node.RateLimit)
 				_ = d.Set("dynamic_ratio", node.DynamicRatio)
 				_ = d.Set("monitor", node.Monitor)
+				// Inverse of the Update mapping: state=user-down -> forced_offline; session=user-disabled (with state=user-up) -> disabled; everything else (including monitor-driven session/state) -> enabled.
+				switch {
+				case node.State == "user-down":
+					_ = d.Set("state", "forced_offline")
+				case node.Session == "user-disabled":
+					_ = d.Set("state", "disabled")
+				default:
+					_ = d.Set("state", "enabled")
+				}
 				found = true
 				break
 			}

--- a/bigip/resource_bigip_ltm_pool_attachment.go
+++ b/bigip/resource_bigip_ltm_pool_attachment.go
@@ -81,9 +81,9 @@ func resourceBigipLtmPoolAttachment() *schema.Resource {
 			"state": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "enabled",
+				Computed:     true,
 				ValidateFunc: validation.StringInSlice([]string{"disabled", "enabled", "forced_offline"}, false),
-				Description:  "Specifies the state the pool member should be in, value can be `enabled` (or) `disabled` (or) forced_offline",
+				Description:  "Specifies the state the pool member should be in, value can be `enabled` (or) `disabled` (or) forced_offline. If unset, Terraform doesn't manage the state and leaves whatever the device reports in place.",
 			},
 			"dynamic_ratio": {
 				Type:        schema.TypeInt,

--- a/bigip/resource_bigip_ltm_pool_attachment_test.go
+++ b/bigip/resource_bigip_ltm_pool_attachment_test.go
@@ -429,6 +429,57 @@ func TestAccBigipLtmPoolAttachment_StateDrift(t *testing.T) {
 	})
 }
 
+// Regression guard for the unset-state behavior: when `state` is not set in
+// config, Terraform must not manage the pool member's state. An out-of-band
+// disable on the device should NOT produce drift on the next plan, and
+// Terraform must not try to re-enable the member.
+func TestAccBigipLtmPoolAttachment_StateUnsetLeavesAlone(t *testing.T) {
+	poolName := "/Common/test_pool_pa_unset_state"
+	memberFullPath := "/Common/10.10.100.22:80"
+	config := `
+		resource "bigip_ltm_pool" "unset" {
+			name                = "` + poolName + `"
+			monitors            = ["/Common/http"]
+			load_balancing_mode = "round-robin"
+		}
+		resource "bigip_ltm_pool_attachment" "unset" {
+			pool = bigip_ltm_pool.unset.name
+			node = "10.10.100.22:80"
+		}`
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAcctPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckPoolsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckPoolAttachment(poolName, memberFullPath, true),
+				),
+			},
+			{
+				// Disable the member out-of-band. Because state is unset in
+				// config, the next plan must remain empty — Terraform leaves
+				// the member alone.
+				PreConfig: func() {
+					client := testAccProvider.Meta().(*bigip.BigIP)
+					patch := &bigip.PoolMember{
+						FullPath: memberFullPath,
+						Session:  "user-disabled",
+						State:    "user-up",
+					}
+					if err := client.ModifyPoolMember2(poolName, patch); err != nil {
+						t.Fatalf("out-of-band patch of pool member failed: %s", err)
+					}
+				},
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func TestAccBigipLtmPoolAttachmentTestCases(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/bigip/resource_bigip_ltm_pool_attachment_test.go
+++ b/bigip/resource_bigip_ltm_pool_attachment_test.go
@@ -377,6 +377,58 @@ func TestAccBigipLtmPoolAttachment_ModifyState(t *testing.T) {
 	})
 }
 
+// Regression guard for https://github.com/F5Networks/terraform-provider-bigip/issues/1116:
+// after Terraform applies state="enabled", an out-of-band change on the device
+// (e.g. an operator disabling the member via the BIG-IP UI) must surface as
+// drift on the next plan rather than being silently masked.
+func TestAccBigipLtmPoolAttachment_StateDrift(t *testing.T) {
+	poolName := "/Common/test_pool_pa_drift"
+	memberFullPath := "/Common/10.10.100.21:80"
+	config := `
+		resource "bigip_ltm_pool" "drift" {
+			name                = "` + poolName + `"
+			monitors            = ["/Common/http"]
+			load_balancing_mode = "round-robin"
+		}
+		resource "bigip_ltm_pool_attachment" "drift" {
+			pool  = bigip_ltm_pool.drift.name
+			node  = "10.10.100.21:80"
+			state = "enabled"
+		}`
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAcctPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckPoolsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckPoolAttachment(poolName, memberFullPath, true),
+					resource.TestCheckResourceAttr("bigip_ltm_pool_attachment.drift", "state", "enabled"),
+				),
+			},
+			{
+				// Mutate the device out-of-band to mimic an operator force-offlining
+				// the member from the BIG-IP UI: session=user-disabled, state=user-down.
+				PreConfig: func() {
+					client := testAccProvider.Meta().(*bigip.BigIP)
+					patch := &bigip.PoolMember{
+						FullPath: memberFullPath,
+						Session:  "user-disabled",
+						State:    "user-down",
+					}
+					if err := client.ModifyPoolMember2(poolName, patch); err != nil {
+						t.Fatalf("out-of-band patch of pool member failed: %s", err)
+					}
+				},
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccBigipLtmPoolAttachmentTestCases(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/docs/resources/bigip_ltm_pool_attachment.md
+++ b/docs/resources/bigip_ltm_pool_attachment.md
@@ -123,7 +123,7 @@ resource "bigip_ltm_pool_attachment" "k8sprod" {
 
 * `monitor` - (Optional) Specifies the health monitors that the system uses to monitor this pool member,value can be `none` (or) `default` (or) list of monitors joined with and ( ex: `/Common/test_monitor_pa_tc1 and /Common/gateway_icmp`).
 
-* `state` - (Optional) Specifies the state the pool member should be in,value can be `enabled` (or) `disabled` (or) `forced_offline`).
+* `state` - (Optional) Specifies the state the pool member should be in, value can be `enabled`, `disabled`, or `forced_offline`. If unset, Terraform doesn't manage the state of the pool member and leaves whatever the device reports in place — useful when the member's state is controlled out-of-band (e.g. from the BIG-IP UI or another system).
 
 * `fqdn_autopopulate` - (Optional) Specifies whether the system automatically creates ephemeral nodes using the IP addresses returned by the resolution of a DNS query for a node defined by an FQDN. The default is enabled
 


### PR DESCRIPTION
## Summary

Two related changes to `bigip_ltm_pool_attachment`'s state handling — together they make the resource correctly detect drift when the user manages `state`, and stay out of the way when they don't.

### 1. Read now refreshes state/session from the device (fixes [#1116](https://github.com/F5Networks/terraform-provider-bigip/issues/1116))

`resourceBigipLtmPoolAttachmentRead` previously read back `priority_group`, `ratio`, `connection_limit`, `connection_rate_limit`, `dynamic_ratio`, and `monitor` from the device but never read `state` or `session`. Result: when a member was disabled out-of-band (e.g. an operator force-offlined it from the BIG-IP UI), Terraform saw no drift and `state = "enabled"` in config never got reconciled.

The Read path now maps the API's `session`/`state` pair back to the resource's pseudo-state field — the inverse of the existing Update mapping:

  | API `state` | API `session` | Resource `state` |
  |---|---|---|
  | `user-down` | (any) | `forced_offline` |
  | `user-up` | `user-disabled` | `disabled` |
  | `user-up` | `user-enabled` / `monitor-*` | `enabled` |

Monitor-driven runtime values (`monitor-enabled`, `up`, `checking`, etc.) collapse to `enabled`, so health-check activity doesn't cause spurious diffs.

### 2. State is no longer managed when unset in config (behavior change)

The `state` field had `Default: "enabled"`, which combined with the new Read-side refresh produced unwanted drift in the common case: a config like

```hcl
resource "bigip_ltm_pool_attachment" "attach_node" {
  node = "/Common/demo-01:80"
  pool = "/Common/demo"
}
```

would refresh `state="disabled"` from a member that an operator had deliberately disabled, then plan would show `disabled` → `enabled` and apply would re-enable it.

The schema is now `Optional + Computed` with no default. When `state` is unset:

- Refresh takes the device's current state (informational only).
- Plan produces no diff for the field.
- Apply doesn't touch session/state on the device — only the explicitly-managed fields (`ratio`, `monitor`, etc.) are sent in the PATCH.

When `state` is explicitly set to `enabled`/`disabled`/`forced_offline`, drift detection works exactly as before — the device value is reconciled to match config.

**This is technically a breaking change** for users who relied on the implicit `Default: "enabled"`. To preserve old behavior they need to add `state = "enabled"` to their config explicitly. Most users either (a) didn't realize the default was there, or (b) wanted the device's actual state respected — both groups benefit from the new behavior.

## What's in the change

- `bigip/resource_bigip_ltm_pool_attachment.go` — Read function now refreshes `state` from the API; schema's `state` field is `Optional + Computed`, no `Default`.
- `bigip/resource_bigip_ltm_pool_attachment_test.go` — two regression-guard acceptance tests:
  - `TestAccBigipLtmPoolAttachment_StateDrift` — applies `state = "enabled"`, patches member out-of-band to mirror the bug-report payload (`session=user-disabled, state=user-down`), asserts plan reports drift.
  - `TestAccBigipLtmPoolAttachment_StateUnsetLeavesAlone` — applies a member without `state`, disables it on the device out-of-band, asserts the next plan is empty.
- `docs/resources/bigip_ltm_pool_attachment.md` — argument doc updated to describe the new unset-leaves-alone behavior.

Companion to [#1157](https://github.com/F5Networks/terraform-provider-bigip/pull/1157), which applies the equivalent Read-path fix to `bigip_ltm_node` for [#1153](https://github.com/F5Networks/terraform-provider-bigip/issues/1153) and adds the canonical `enabled`/`disabled`/`forced_offline` interface there.

## Test plan

- [ ] `make test` passes (compile + unit tests)
- [ ] `TF_ACC=1 go test ./bigip/ -run TestAccBigipLtmPoolAttachment_StateDrift -timeout=10m -v` passes against a real BIG-IP
- [ ] `TF_ACC=1 go test ./bigip/ -run TestAccBigipLtmPoolAttachment_StateUnsetLeavesAlone -timeout=10m -v` passes against a real BIG-IP
- [ ] Existing `TestAccBigipLtmPoolAttachment_StateSet` and `TestAccBigipLtmPoolAttachment_ModifyState` still pass — they now genuinely exercise the Read path's state normalization
- [ ] Manual upgrade test: a config with no `state` line and a member previously disabled on the device — confirm `terraform plan` reports no changes (was: would re-enable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)