### PR TITLE
feat: support enabled/disabled/forced_offline state on bigip_ltm_node

### DIFF
--- a/bigip/resource_bigip_ltm_node.go
+++ b/bigip/resource_bigip_ltm_node.go
@@ -81,12 +81,12 @@ func resourceBigipLtmNode() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				Description: "Marks the node up or down. The default value is user-up.",
+				Description: "Specifies the state of the node. Preferred values are `enabled`, `disabled`, or `forced_offline`. Legacy values `user-up` and `user-down` are accepted for backwards compatibility; in legacy mode pair them with the `session` field (`user-enabled` or `user-disabled`) to fully describe the desired state.",
 			},
 			"session": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Enables or disables the node for new sessions. The default value is user-enabled.",
+				Description: "Legacy field controlling whether the node accepts new sessions (`user-enabled` or `user-disabled`). Ignored when `state` is set to `enabled`/`disabled`/`forced_offline`, since those values control session implicitly.",
 				Computed:    true,
 			},
 			"fqdn": {
@@ -145,6 +145,11 @@ func resourceBigipLtmNodeCreate(ctx context.Context, d *schema.ResourceData, met
 	description := d.Get("description").(string)
 	ratio := d.Get("ratio").(int)
 
+	apiState, apiSession := translateNodeState(state, session)
+	if isCanonicalNodeState(state) && session != "" && session != apiSession {
+		log.Printf("[WARN] state=%q overrides explicit session=%q; canonical state values control session implicitly", state, session)
+	}
+
 	r := regexp.MustCompile("^((?:[0-9]{1,3}.){3}[0-9]{1,3})|(.*:[^%]*)$")
 
 	log.Println("[INFO] Creating node " + name + "::" + address)
@@ -155,8 +160,8 @@ func resourceBigipLtmNodeCreate(ctx context.Context, d *schema.ResourceData, met
 		ConnectionLimit: connectionLimit,
 		DynamicRatio:    dynamicRatio,
 		Monitor:         monitor,
-		State:           state,
-		Session:         session,
+		State:           apiState,
+		Session:         apiSession,
 		Description:     description,
 		Ratio:           ratio,
 	}
@@ -222,11 +227,10 @@ func resourceBigipLtmNodeRead(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.FromErr(fmt.Errorf("[DEBUG] Error saving Monitor to state for Node (%s): %s", d.Id(), err))
 	}
 
-	if (node.Session == "monitor-enabled") || (node.Session == "user-enabled") {
-		_ = d.Set("session", "user-enabled")
-	} else {
-		_ = d.Set("session", "user-disabled")
-	}
+	priorState := d.Get("state").(string)
+	state, session := nodeStateForRead(priorState, node.State, node.Session)
+	_ = d.Set("state", state)
+	_ = d.Set("session", session)
 	_ = d.Set("connection_limit", node.ConnectionLimit)
 	_ = d.Set("description", node.Description)
 	_ = d.Set("dynamic_ratio", node.DynamicRatio)
@@ -272,13 +276,20 @@ func resourceBigipLtmNodeUpdate(ctx context.Context, d *schema.ResourceData, met
 	address := d.Get("address").(string)
 	r := regexp.MustCompile("^((?:[0-9]{1,3}.){3}[0-9]{1,3})|(.*:[^%]*)$")
 
+	state := d.Get("state").(string)
+	session := d.Get("session").(string)
+	apiState, apiSession := translateNodeState(state, session)
+	if isCanonicalNodeState(state) && session != "" && session != apiSession {
+		log.Printf("[WARN] state=%q overrides explicit session=%q; canonical state values control session implicitly", state, session)
+	}
+
 	nodeConfig := &bigip.Node{
 		ConnectionLimit: d.Get("connection_limit").(int),
 		DynamicRatio:    d.Get("dynamic_ratio").(int),
 		Monitor:         d.Get("monitor").(string),
 		RateLimit:       d.Get("rate_limit").(string),
-		State:           d.Get("state").(string),
-		Session:         d.Get("session").(string),
+		State:           apiState,
+		Session:         apiSession,
 		Description:     d.Get("description").(string),
 		Ratio:           d.Get("ratio").(int),
 	}
@@ -292,6 +303,59 @@ func resourceBigipLtmNodeUpdate(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	return resourceBigipLtmNodeRead(ctx, d, meta)
+}
+
+// isCanonicalNodeState reports whether s is one of the preferred enabled/
+// disabled/forced_offline values that map cleanly onto a (state, session)
+// API tuple.
+func isCanonicalNodeState(s string) bool {
+	return s == "enabled" || s == "disabled" || s == "forced_offline"
+}
+
+// translateNodeState converts the user-facing state value into the
+// (apiState, apiSession) tuple sent to BIG-IP. Canonical values expand into
+// both fields; legacy values (user-up/user-down) and empty pass through with
+// the user-supplied session.
+func translateNodeState(state, session string) (string, string) {
+	switch state {
+	case "enabled":
+		return "user-up", "user-enabled"
+	case "disabled":
+		return "user-up", "user-disabled"
+	case "forced_offline":
+		return "user-down", "user-disabled"
+	default:
+		return state, session
+	}
+}
+
+// nodeStateForRead picks how to present the API's state/session pair back to
+// Terraform state, keyed off the prior value already stored. Canonical or
+// empty prior -> canonical form; legacy prior -> preserved legacy form so
+// existing configs stay diff-free.
+func nodeStateForRead(prior, apiState, apiSession string) (state, session string) {
+	if apiSession == "monitor-enabled" || apiSession == "user-enabled" {
+		session = "user-enabled"
+	} else {
+		session = "user-disabled"
+	}
+	if isCanonicalNodeState(prior) || prior == "" {
+		switch {
+		case apiState == "user-down":
+			state = "forced_offline"
+		case session == "user-disabled":
+			state = "disabled"
+		default:
+			state = "enabled"
+		}
+		return
+	}
+	if apiState == "user-down" {
+		state = "user-down"
+	} else {
+		state = "user-up"
+	}
+	return
 }
 
 func resourceBigipLtmNodeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/bigip/resource_bigip_ltm_node_test.go
+++ b/bigip/resource_bigip_ltm_node_test.go
@@ -144,6 +144,59 @@ func TestAccBigipLtmNode_FqdnCreate(t *testing.T) {
 		},
 	})
 }
+// Exercises the canonical state interface (enabled/disabled/forced_offline)
+// on bigip_ltm_node, mirroring the model used by bigip_ltm_pool_attachment.
+// Walks through the three values to verify Create+Update+Read round-trip.
+func TestAccBigipLtmNode_CanonicalState(t *testing.T) {
+	t.Parallel()
+	instName := "test-node-canonical-state"
+	nodeName := fmt.Sprintf("/%s/%s", TestPartition, instName)
+	resFullName := fmt.Sprintf("%s.%s", resNodeName, instName)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckNodesDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testaccbigipltmNodeCanonicalStateConfig(instName, "enabled"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckNodeExists(nodeName),
+					resource.TestCheckResourceAttr(resFullName, "state", "enabled"),
+					resource.TestCheckResourceAttr(resFullName, "session", "user-enabled"),
+				),
+			},
+			{
+				Config: testaccbigipltmNodeCanonicalStateConfig(instName, "disabled"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckNodeExists(nodeName),
+					resource.TestCheckResourceAttr(resFullName, "state", "disabled"),
+					resource.TestCheckResourceAttr(resFullName, "session", "user-disabled"),
+				),
+			},
+			{
+				Config: testaccbigipltmNodeCanonicalStateConfig(instName, "forced_offline"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckNodeExists(nodeName),
+					resource.TestCheckResourceAttr(resFullName, "state", "forced_offline"),
+					resource.TestCheckResourceAttr(resFullName, "session", "user-disabled"),
+				),
+			},
+		},
+	})
+}
+
+func testaccbigipltmNodeCanonicalStateConfig(instName, state string) string {
+	return fmt.Sprintf(`
+resource "bigip_ltm_node" "%[1]s" {
+  name    = "/Common/%[1]s"
+  address = "192.168.100.102"
+  state   = "%[2]s"
+}
+`, instName, state)
+}
+
 func TestAccBigipLtmNodeUpdateMonitor(t *testing.T) {
 	t.Parallel()
 	var instName = "test-node-monitor"

--- a/bigip/resource_bigip_ltm_node_unit_test.go
+++ b/bigip/resource_bigip_ltm_node_unit_test.go
@@ -19,6 +19,59 @@ import (
 	"testing"
 )
 
+func TestTranslateNodeState(t *testing.T) {
+	cases := []struct {
+		name           string
+		state, session string
+		wantState      string
+		wantSession    string
+	}{
+		{"canonical enabled", "enabled", "", "user-up", "user-enabled"},
+		{"canonical disabled", "disabled", "", "user-up", "user-disabled"},
+		{"canonical forced_offline", "forced_offline", "", "user-down", "user-disabled"},
+		{"canonical state ignores explicit session", "enabled", "user-disabled", "user-up", "user-enabled"},
+		{"legacy user-up passes through", "user-up", "user-enabled", "user-up", "user-enabled"},
+		{"legacy user-down passes through", "user-down", "user-disabled", "user-down", "user-disabled"},
+		{"empty passes through", "", "", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotState, gotSession := translateNodeState(tc.state, tc.session)
+			assert.Equal(t, tc.wantState, gotState, "state")
+			assert.Equal(t, tc.wantSession, gotSession, "session")
+		})
+	}
+}
+
+func TestNodeStateForRead(t *testing.T) {
+	cases := []struct {
+		name                  string
+		prior                 string
+		apiState, apiSession  string
+		wantState, wantSession string
+	}{
+		// Canonical-prior scenarios (new style)
+		{"canonical prior, healthy", "enabled", "user-up", "monitor-enabled", "enabled", "user-enabled"},
+		{"canonical prior, user-disabled", "enabled", "user-up", "user-disabled", "disabled", "user-disabled"},
+		{"canonical prior, force-offlined", "enabled", "user-down", "user-disabled", "forced_offline", "user-disabled"},
+		{"canonical prior, monitor reports down (still user-up)", "enabled", "down", "monitor-enabled", "enabled", "user-enabled"},
+		// Legacy-prior scenarios (preserve current behavior)
+		{"legacy prior user-up, monitor-enabled", "user-up", "user-up", "monitor-enabled", "user-up", "user-enabled"},
+		{"legacy prior user-up, user-disabled", "user-up", "user-up", "user-disabled", "user-up", "user-disabled"},
+		{"legacy prior user-down, force offline", "user-down", "user-down", "user-disabled", "user-down", "user-disabled"},
+		// Empty prior (fresh import) defaults to canonical
+		{"empty prior treated as canonical", "", "user-up", "monitor-enabled", "enabled", "user-enabled"},
+		{"empty prior, force-offlined device", "", "user-down", "user-disabled", "forced_offline", "user-disabled"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotState, gotSession := nodeStateForRead(tc.prior, tc.apiState, tc.apiSession)
+			assert.Equal(t, tc.wantState, gotState, "state")
+			assert.Equal(t, tc.wantSession, gotSession, "session")
+		})
+	}
+}
+
 func testBigipLtmNodeInvalid(resourceName string) string {
 	return fmt.Sprintf(`
 resource "bigip_ltm_node" "test-node" {

--- a/docs/resources/bigip_ltm_node.md
+++ b/docs/resources/bigip_ltm_node.md
@@ -48,9 +48,9 @@ resource "bigip_ltm_node" "node" {
 
 * `rate_limit`- (Optional,type `string`) Specifies the maximum number of connections per second allowed for a node or node address. The default value is 'disabled'.
 
-* `state` - (Optional) Default is "user-up" you can set to "user-down" if you want to disable
+* `state` - (Optional) Specifies the state of the node. Preferred values are `enabled`, `disabled`, or `forced_offline`, which map cleanly onto the underlying state and session controls (this matches the model used by `bigip_ltm_pool_attachment`). The legacy values `user-up` and `user-down` are still accepted; in legacy mode pair them with the `session` field below (`user-enabled` or `user-disabled`) to fully describe the desired state.
 
-* `session` - (Optional) Enables or disables the node for new sessions. Can be set to `user-enabled` or `user-disabled`. (Default: `user-enabled`).
+* `session` - (Optional, legacy) Controls whether the node accepts new sessions: `user-enabled` or `user-disabled`. Ignored when `state` is set to `enabled`/`disabled`/`forced_offline`, since those values control session implicitly.
 
 ### fqdn(fully qualified domain name) Configuration Block
 


### PR DESCRIPTION
## Summary

- Aligns the `state` interface on `bigip_ltm_node` with the model already used by `bigip_ltm_pool_attachment`. The `state` field now accepts canonical values — `enabled`, `disabled`, `forced_offline` — which expand internally into the `(state, session)` tuple sent to BIG-IP:

  | Resource `state` | API `state` | API `session` |
  |---|---|---|
  | `enabled` | `user-up` | `user-enabled` |
  | `disabled` | `user-up` | `user-disabled` |
  | `forced_offline` | `user-down` | `user-disabled` |

- **Backwards compatible.** The legacy values `user-up` / `user-down` still work, and the `session` field is still honored when paired with them. Existing configs continue to apply with no diff.
- **Read picks the return style based on the prior value already in state.** Canonical prior (or empty — e.g. on import) → canonical form; legacy prior → legacy form preserved. This means upgrading users see no churn, and a user can opt into the canonical interface simply by changing their config.
- **Fixes [#1153](https://github.com/F5Networks/terraform-provider-bigip/issues/1153) along the way.** The previous Read function never refreshed `state` from the device, so a manual force-offline went undetected. The new Read path always refreshes both fields. (This supersedes my earlier minimal-fix PR [#1155](https://github.com/F5Networks/terraform-provider-bigip/pull/1155); happy to close that one once this lands.)

## What's in the change

- `bigip/resource_bigip_ltm_node.go` — schema descriptions updated, three new private helpers (`isCanonicalNodeState`, `translateNodeState`, `nodeStateForRead`), and Create/Update/Read wired through them. Conflicting input (canonical `state` plus an explicit non-matching `session`) emits a `[WARN]` log with `state` taking precedence.
- `bigip/resource_bigip_ltm_node_unit_test.go` — `TestTranslateNodeState` (7 cases) and `TestNodeStateForRead` (9 cases) covering canonical, legacy, conflict, and empty-prior (fresh import) scenarios.
- `bigip/resource_bigip_ltm_node_test.go` — `TestAccBigipLtmNode_CanonicalState` rotates a node through `enabled` → `disabled` → `forced_offline`, asserting both `state` and `session` round-trip on a real BIG-IP.
- `docs/resources/bigip_ltm_node.md` — argument docs updated to describe the canonical and legacy forms.

Companion to [#1156](https://github.com/F5Networks/terraform-provider-bigip/pull/1156), which applies the equivalent Read-path drift fix to `bigip_ltm_pool_attachment` for [#1116](https://github.com/F5Networks/terraform-provider-bigip/issues/1116).

## Test plan

- [x] `go test ./bigip/ -run \"TestTranslateNodeState|TestNodeStateForRead\"` — 16/16 pass
- [ ] `make test` — compiles + unit tests pass
- [ ] `TF_ACC=1 go test ./bigip/ -run TestAccBigipLtmNode_CanonicalState -timeout=10m -v` — runs the canonical state walk-through against a real BIG-IP
- [ ] Manual upgrade test: take a node previously applied with `state = \"user-up\"`, upgrade the provider, run `terraform plan` — confirm no diff. Then change the config to `state = \"enabled\"` and confirm a single one-time diff `user-up` → `enabled` and a clean apply afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)