### PR TITLE
feat: gtm wideip pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 1.4.0 (Unreleased)
+
+# Features additions:
+
+ - Added `pools` attribute to `bigip_gtm_wideip` resource for associating GTM pools with a WideIP
 ## 1.3.0 (July 23, 2020)
 
 # Features additions:

--- a/bigip/gtm_wideip_pools_test.go
+++ b/bigip/gtm_wideip_pools_test.go
@@ -1,0 +1,78 @@
+//go:build unit
+// +build unit
+
+/*
+Copyright 2019 F5 Networks Inc.
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+package bigip
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// TestResourceBigipGtmWideipPoolsSchemaExists reproduces the customer-reported
+// issue: the bigip_gtm_wideip resource has no "pools" attribute, so there is
+// no way to associate pools with a WideIP. Without the fix this test fails
+// with: 'Expected "pools" field to exist in schema'.
+func TestResourceBigipGtmWideipPoolsSchemaExists(t *testing.T) {
+	resource := resourceBigipGtmWideip()
+
+	poolsSchema, ok := resource.Schema["pools"]
+	if !ok {
+		t.Fatal("Expected 'pools' field to exist in schema. The bigip_gtm_wideip resource does not support associating pools.")
+	}
+
+	if poolsSchema.Type != schema.TypeList {
+		t.Errorf("Expected 'pools' to be TypeList, got %v", poolsSchema.Type)
+	}
+
+	if !poolsSchema.Optional {
+		t.Error("Expected 'pools' to be optional")
+	}
+
+	// Verify the nested resource schema
+	poolElem, ok := poolsSchema.Elem.(*schema.Resource)
+	if !ok {
+		t.Fatal("Expected 'pools' Elem to be a *schema.Resource")
+	}
+
+	// Verify 'name' sub-field
+	nameField, ok := poolElem.Schema["name"]
+	if !ok {
+		t.Fatal("Expected 'pools.name' field to exist")
+	}
+	if !nameField.Required {
+		t.Error("Expected 'pools.name' to be required")
+	}
+	if nameField.Type != schema.TypeString {
+		t.Errorf("Expected 'pools.name' to be TypeString, got %v", nameField.Type)
+	}
+
+	// Verify 'order' sub-field
+	orderField, ok := poolElem.Schema["order"]
+	if !ok {
+		t.Fatal("Expected 'pools.order' field to exist")
+	}
+	if orderField.Type != schema.TypeInt {
+		t.Errorf("Expected 'pools.order' to be TypeInt, got %v", orderField.Type)
+	}
+	if orderField.Default != 0 {
+		t.Errorf("Expected 'pools.order' default to be 0, got %v", orderField.Default)
+	}
+
+	// Verify 'ratio' sub-field
+	ratioField, ok := poolElem.Schema["ratio"]
+	if !ok {
+		t.Fatal("Expected 'pools.ratio' field to exist")
+	}
+	if ratioField.Type != schema.TypeInt {
+		t.Errorf("Expected 'pools.ratio' to be TypeInt, got %v", ratioField.Type)
+	}
+	if ratioField.Default != 1 {
+		t.Errorf("Expected 'pools.ratio' default to be 1, got %v", ratioField.Default)
+	}
+}

--- a/bigip/resource_bigip_gtm_wideip.go
+++ b/bigip/resource_bigip_gtm_wideip.go
@@ -269,19 +269,18 @@ func resourceBigipGtmWideipRead(ctx context.Context, d *schema.ResourceData, met
 		d.Set("aliases", wideip.Aliases)
 	}
 
-	// Handle Pools
-	if len(wideip.Pools) > 0 {
-		pools := make([]interface{}, 0, len(wideip.Pools))
-		for _, pool := range wideip.Pools {
-			poolMap := map[string]interface{}{
-				"name":  pool.Name,
-				"order": pool.Order,
-				"ratio": pool.Ratio,
-			}
-			pools = append(pools, poolMap)
+	// Handle Pools — always set, even when empty, so that external removal
+	// of pools is detected as drift rather than leaving stale state.
+	pools := make([]interface{}, 0, len(wideip.Pools))
+	for _, pool := range wideip.Pools {
+		poolMap := map[string]interface{}{
+			"name":  pool.Name,
+			"order": pool.Order,
+			"ratio": pool.Ratio,
 		}
-		d.Set("pools", pools)
+		pools = append(pools, poolMap)
 	}
+	d.Set("pools", pools)
 
 	return nil
 }
@@ -337,21 +336,20 @@ func resourceBigipGtmWideipUpdate(ctx context.Context, d *schema.ResourceData, m
 		wideip.Aliases = aliasesList
 	}
 
-	// Handle Pools
-	if v, ok := d.GetOk("pools"); ok {
-		poolsList := v.([]interface{})
-		pools := make([]bigip.GTMWideIPPool, 0, len(poolsList))
-		for _, item := range poolsList {
-			poolMap := item.(map[string]interface{})
-			pool := bigip.GTMWideIPPool{
-				Name:  poolMap["name"].(string),
-				Order: poolMap["order"].(int),
-				Ratio: poolMap["ratio"].(int),
-			}
-			pools = append(pools, pool)
+	// Handle Pools — always set the field so that removing all pools from
+	// the config sends an empty list to the API instead of omitting it.
+	poolsList := d.Get("pools").([]interface{})
+	pools := make([]bigip.GTMWideIPPool, 0, len(poolsList))
+	for _, item := range poolsList {
+		poolMap := item.(map[string]interface{})
+		pool := bigip.GTMWideIPPool{
+			Name:  poolMap["name"].(string),
+			Order: poolMap["order"].(int),
+			Ratio: poolMap["ratio"].(int),
 		}
-		wideip.Pools = pools
+		pools = append(pools, pool)
 	}
+	wideip.Pools = pools
 
 	err := client.ModifyGTMWideIP(fullPath, wideip, recordType)
 	if err != nil {

--- a/bigip/resource_bigip_gtm_wideip.go
+++ b/bigip/resource_bigip_gtm_wideip.go
@@ -137,6 +137,32 @@ func resourceBigipGtmWideip() *schema.Resource {
 				},
 				Description: "Specifies alternate domain names for the WideIP",
 			},
+			"pools": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Name of the GTM pool to associate with the WideIP (e.g., '/Common/mypool')",
+						},
+						"order": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     0,
+							Description: "Specifies the order of the pool within the WideIP",
+						},
+						"ratio": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     1,
+							Description: "Specifies the weight of the pool for load balancing",
+						},
+					},
+				},
+				Description: "Specifies the pools this WideIP uses for load balancing",
+			},
 		},
 	}
 }
@@ -243,6 +269,20 @@ func resourceBigipGtmWideipRead(ctx context.Context, d *schema.ResourceData, met
 		d.Set("aliases", wideip.Aliases)
 	}
 
+	// Handle Pools
+	if len(wideip.Pools) > 0 {
+		pools := make([]interface{}, 0, len(wideip.Pools))
+		for _, pool := range wideip.Pools {
+			poolMap := map[string]interface{}{
+				"name":  pool.Name,
+				"order": pool.Order,
+				"ratio": pool.Ratio,
+			}
+			pools = append(pools, poolMap)
+		}
+		d.Set("pools", pools)
+	}
+
 	return nil
 }
 
@@ -295,6 +335,22 @@ func resourceBigipGtmWideipUpdate(ctx context.Context, d *schema.ResourceData, m
 			aliasesList = append(aliasesList, item.(string))
 		}
 		wideip.Aliases = aliasesList
+	}
+
+	// Handle Pools
+	if v, ok := d.GetOk("pools"); ok {
+		poolsList := v.([]interface{})
+		pools := make([]bigip.GTMWideIPPool, 0, len(poolsList))
+		for _, item := range poolsList {
+			poolMap := item.(map[string]interface{})
+			pool := bigip.GTMWideIPPool{
+				Name:  poolMap["name"].(string),
+				Order: poolMap["order"].(int),
+				Ratio: poolMap["ratio"].(int),
+			}
+			pools = append(pools, pool)
+		}
+		wideip.Pools = pools
 	}
 
 	err := client.ModifyGTMWideIP(fullPath, wideip, recordType)

--- a/docs/resources/bigip_gtm_wideip.md
+++ b/docs/resources/bigip_gtm_wideip.md
@@ -28,6 +28,32 @@ resource "bigip_gtm_wideip" "example" {
 }
 ```
 
+### WideIP with Pools
+
+```hcl
+resource "bigip_gtm_wideip" "with_pools" {
+  name      = "app.example.com"
+  type      = "a"
+  partition = "Common"
+
+  description      = "Application WideIP with pools"
+  pool_lb_mode     = "round-robin"
+  minimal_response = "enabled"
+
+  pools {
+    name  = "/Common/primarypool"
+    order = 0
+    ratio = 1
+  }
+
+  pools {
+    name  = "/Common/secondarypool"
+    order = 1
+    ratio = 2
+  }
+}
+```
+
 ### WideIP with Last Resort Pool
 
 ```hcl
@@ -112,6 +138,10 @@ The following arguments are supported:
 * `ttl_persistence` - (Optional, Integer) Specifies the time to live (TTL) in seconds for persistence records. Default: `3600`.
 * `topology_prefer_edns0_client_subnet` - (Optional, String) Specifies whether to prefer EDNS0 client subnet data for topology-based load balancing. Valid values: `enabled`, `disabled`. Default: `disabled`.
 * `aliases` - (Optional, Set of Strings) Specifies alternate domain names (aliases) for the WideIP. These are additional names that resolve to the same WideIP configuration. Example: `["alias1.example.com", "alias2.example.com"]`.
+* `pools` - (Optional, List of Objects) Specifies the pools this WideIP uses for load balancing. Each pool block supports:
+  * `name` - (Required, String) Name of the GTM pool to associate with the WideIP (e.g., `/Common/mypool`).
+  * `order` - (Optional, Integer) Specifies the order of the pool within the WideIP. Lower values are evaluated first. Default: `0`.
+  * `ratio` - (Optional, Integer) Specifies the weight of the pool for load balancing. Default: `1`.
 
 ## Attribute Reference
 
@@ -226,4 +256,5 @@ This resource interacts with the following BIG-IP API endpoints:
 - `bigip_gtm_pool` - Manages GTM pools that can be referenced by WideIPs
 - `bigip_gtm_server` - Manages GTM servers that contain virtual servers
 - `bigip_gtm_datacenter` - Manages GTM data centers
-- `bigip_gtm_topology` - Manages topology records for topology-based load balancing
+- `bigip_gtm_topology_record` - Manages topology records for topology-based load balancing
+- `bigip_gtm_topology_region` - Manages topology regions for topology-based load balancing

--- a/vendor/github.com/f5devcentral/go-bigip/gtm.go
+++ b/vendor/github.com/f5devcentral/go-bigip/gtm.go
@@ -32,8 +32,8 @@ type Datacenters struct {
 type GTMWideIPPool struct {
 	Name      string `json:"name,omitempty"`
 	Partition string `json:"partition,omitempty"`
-	Order     int    `json:"order,omitempty"`
-	Ratio     int    `json:"ratio,omitempty"`
+	Order     int    `json:"order"`
+	Ratio     int    `json:"ratio"`
 }
 
 type GTMWideIP struct {

--- a/vendor/github.com/f5devcentral/go-bigip/gtm.go
+++ b/vendor/github.com/f5devcentral/go-bigip/gtm.go
@@ -58,7 +58,7 @@ type GTMWideIP struct {
 	TopologyPreferEdns0ClientSubnet   string          `json:"topologyPreferEdns0ClientSubnet,omitempty"`
 	TTLPersistence                    int             `json:"ttlPersistence,omitempty"`
 	Aliases                           []string        `json:"aliases,omitempty"`
-	Pools                             []GTMWideIPPool `json:"pools,omitempty"`
+	Pools                             []GTMWideIPPool `json:"pools"`
 }
 
 // type Datacenter struct {

--- a/vendor/github.com/f5devcentral/go-bigip/gtm.go
+++ b/vendor/github.com/f5devcentral/go-bigip/gtm.go
@@ -28,32 +28,37 @@ type Datacenters struct {
 	Datacenters []GTMDatacenter `json:"items"`
 }
 
-type GTMWideIP struct {
-	Name                              string   `json:"name,omitempty"`
-	Partition                         string   `json:"partition,omitempty"`
-	FullPath                          string   `json:"fullPath,omitempty"`
-	Generation                        int      `json:"generation,omitempty"`
-	AppService                        string   `json:"appService,omitempty"`
-	Description                       string   `json:"description,omitempty"`
-	Disabled                          bool     `json:"disabled,omitempty"`
-	Enabled                           bool     `json:"enabled,omitempty"`
-	FailureRcode                      string   `json:"failureRcode,omitempty"`
-	FailureRcodeResponse              string   `json:"failureRcodeResponse,omitempty"`
-	FailureRcodeTTL                   int      `json:"failureRcodeTtl,omitempty"`
-	LastResortPool                    string   `json:"lastResortPool,omitempty"`
-	LoadBalancingDecisionLogVerbosity []string `json:"loadBalancingDecisionLogVerbosity,omitempty"`
-	MinimalResponse                   string   `json:"minimalResponse,omitempty"`
-	PersistCidrIpv4                   int      `json:"persistCidrIpv4,omitempty"`
-	PersistCidrIpv6                   int      `json:"persistCidrIpv6,omitempty"`
-	Persistence                       string   `json:"persistence,omitempty"`
-	PoolLbMode                        string   `json:"poolLbMode,omitempty"`
-	TopologyPreferEdns0ClientSubnet   string   `json:"topologyPreferEdns0ClientSubnet,omitempty"`
-	TTLPersistence                    int      `json:"ttlPersistence,omitempty"`
-	Aliases                           []string `json:"aliases,omitempty"`
+// GTMWideIPPool represents a pool associated with a GTM WideIP
+type GTMWideIPPool struct {
+	Name      string `json:"name,omitempty"`
+	Partition string `json:"partition,omitempty"`
+	Order     int    `json:"order,omitempty"`
+	Ratio     int    `json:"ratio,omitempty"`
+}
 
-	// Not in the spec, but returned by the API
-	// Setting this field atomically updates all members.
-	//Pools *[]GTMWideIPPool `json:"pools,omitempty"`
+type GTMWideIP struct {
+	Name                              string          `json:"name,omitempty"`
+	Partition                         string          `json:"partition,omitempty"`
+	FullPath                          string          `json:"fullPath,omitempty"`
+	Generation                        int             `json:"generation,omitempty"`
+	AppService                        string          `json:"appService,omitempty"`
+	Description                       string          `json:"description,omitempty"`
+	Disabled                          bool            `json:"disabled,omitempty"`
+	Enabled                           bool            `json:"enabled,omitempty"`
+	FailureRcode                      string          `json:"failureRcode,omitempty"`
+	FailureRcodeResponse              string          `json:"failureRcodeResponse,omitempty"`
+	FailureRcodeTTL                   int             `json:"failureRcodeTtl,omitempty"`
+	LastResortPool                    string          `json:"lastResortPool,omitempty"`
+	LoadBalancingDecisionLogVerbosity []string        `json:"loadBalancingDecisionLogVerbosity,omitempty"`
+	MinimalResponse                   string          `json:"minimalResponse,omitempty"`
+	PersistCidrIpv4                   int             `json:"persistCidrIpv4,omitempty"`
+	PersistCidrIpv6                   int             `json:"persistCidrIpv6,omitempty"`
+	Persistence                       string          `json:"persistence,omitempty"`
+	PoolLbMode                        string          `json:"poolLbMode,omitempty"`
+	TopologyPreferEdns0ClientSubnet   string          `json:"topologyPreferEdns0ClientSubnet,omitempty"`
+	TTLPersistence                    int             `json:"ttlPersistence,omitempty"`
+	Aliases                           []string        `json:"aliases,omitempty"`
+	Pools                             []GTMWideIPPool `json:"pools,omitempty"`
 }
 
 // type Datacenter struct {


### PR DESCRIPTION
The `bigip_gtm_wideip` resource does not support associating pools with a WideIP. While the `last_resort_pool` attribute exists, there is no way to configure primary pools — a fundamental GTM WideIP capability. The BIG-IP API supports a `pools` array on WideIP objects, and the SDK struct even had a commented-out `Pools` field, but it was never wired through to the Terraform resource schema.

This means users cannot define which GTM pools a WideIP should use for load balancing, severely limiting the usefulness of the resource.

### Solution

Added `pools` support to the `bigip_gtm_wideip` resource by:

- **SDK (`vendor/github.com/f5devcentral/go-bigip/gtm.go`):** Defined a new `GTMWideIPPool` struct with `name`, `partition`, `order`, and `ratio` fields, and added a `Pools` field to the `GTMWideIP` struct that serializes to/from the BIG-IP API's `pools` JSON array.

- **Resource (`bigip/resource_bigip_gtm_wideip.go`):** Added an optional `pools` block to the schema with sub-attributes `name` (required), `order` (default 0), and `ratio` (default 1). Wired pool data through the Read and Update functions so pools are correctly read from the API and sent on create/update.

### Example Usage

```hcl
resource "bigip_gtm_wideip" "example" {
  name         = "example.local"
  type         = "a"
  pool_lb_mode = "round-robin"

  pools {
    name  = "/Common/primarypool"
    order = 0
    ratio = 1
  }

  pools {
    name  = "/Common/secondarypool"
    order = 1
    ratio = 2
  }
}
