### PR TITLE
feat: add data sources for gtm datacenter and server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 # Features additions:
 
  - Added `pools` attribute to `bigip_gtm_wideip` resource for associating GTM pools with a WideIP
+ - Added `bigip_gtm_datacenter` data source for reading existing GTM datacenters
+ - Added `bigip_gtm_server` data source for reading existing GTM servers
+
 ## 1.3.0 (July 23, 2020)
 
 # Features additions:

--- a/bigip/datasource_bigip_gtm_datacenter.go
+++ b/bigip/datasource_bigip_gtm_datacenter.go
@@ -1,0 +1,94 @@
+package bigip
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	bigip "github.com/f5devcentral/go-bigip"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceBigipGtmDatacenter() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceBigipGtmDatacenterRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the GTM datacenter",
+			},
+			"partition": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Partition of the GTM datacenter",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Description of the datacenter",
+			},
+			"contact": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Contact information for the datacenter",
+			},
+			"enabled": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the datacenter is enabled",
+			},
+			"location": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Location of the datacenter",
+			},
+			"prober_fallback": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Type of prober to use for fallback",
+			},
+			"prober_preference": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Type of prober to prefer",
+			},
+		},
+	}
+}
+
+func dataSourceBigipGtmDatacenterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+
+	name := d.Get("name").(string)
+	partition := d.Get("partition").(string)
+	fullPath := fmt.Sprintf("/%s/%s", partition, name)
+
+	log.Printf("[DEBUG] Reading GTM Datacenter data source: %s", fullPath)
+
+	datacenter, err := client.GetGTMDatacenter(fullPath)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error retrieving GTM Datacenter %s: %v", fullPath, err))
+	}
+	if datacenter == nil {
+		return diag.FromErr(fmt.Errorf("GTM Datacenter %s not found", fullPath))
+	}
+
+	d.SetId(fullPath)
+	d.Set("name", datacenter.Name)
+	d.Set("partition", datacenter.Partition)
+	d.Set("description", datacenter.Description)
+	d.Set("contact", datacenter.Contact)
+	d.Set("location", datacenter.Location)
+	d.Set("prober_fallback", datacenter.ProberFallback)
+	d.Set("prober_preference", datacenter.ProberPreference)
+
+	if datacenter.Disabled {
+		d.Set("enabled", false)
+	} else {
+		d.Set("enabled", true)
+	}
+
+	return nil
+}

--- a/bigip/datasource_bigip_gtm_datacenter_test.go
+++ b/bigip/datasource_bigip_gtm_datacenter_test.go
@@ -1,0 +1,40 @@
+//go:build unit
+// +build unit
+
+package bigip
+
+import (
+	"testing"
+)
+
+func TestDataSourceBigipGtmDatacenterSchema(t *testing.T) {
+	ds := dataSourceBigipGtmDatacenter()
+
+	if ds.ReadContext == nil {
+		t.Fatal("Expected ReadContext to be defined")
+	}
+
+	requiredFields := []string{"name", "partition"}
+	for _, field := range requiredFields {
+		s, ok := ds.Schema[field]
+		if !ok {
+			t.Errorf("Expected field '%s' to exist", field)
+			continue
+		}
+		if !s.Required {
+			t.Errorf("Expected field '%s' to be required", field)
+		}
+	}
+
+	computedFields := []string{"description", "contact", "enabled", "location", "prober_fallback", "prober_preference"}
+	for _, field := range computedFields {
+		s, ok := ds.Schema[field]
+		if !ok {
+			t.Errorf("Expected field '%s' to exist", field)
+			continue
+		}
+		if !s.Computed {
+			t.Errorf("Expected field '%s' to be computed", field)
+		}
+	}
+}

--- a/bigip/datasource_bigip_gtm_provider_test.go
+++ b/bigip/datasource_bigip_gtm_provider_test.go
@@ -1,0 +1,30 @@
+//go:build unit
+// +build unit
+
+package bigip
+
+import (
+	"testing"
+)
+
+// TestDataSourceBigipGtmDatacenterExists proves that a data source for GTM
+// datacenters is registered in the provider. Without the fix, this test fails
+// because no such data source exists.
+func TestDataSourceBigipGtmDatacenterExists(t *testing.T) {
+	p := Provider()
+
+	if _, ok := p.DataSourcesMap["bigip_gtm_datacenter"]; !ok {
+		t.Fatal("Expected data source 'bigip_gtm_datacenter' to be registered in the provider")
+	}
+}
+
+// TestDataSourceBigipGtmServerExists proves that a data source for GTM
+// servers is registered in the provider. Without the fix, this test fails
+// because no such data source exists.
+func TestDataSourceBigipGtmServerExists(t *testing.T) {
+	p := Provider()
+
+	if _, ok := p.DataSourcesMap["bigip_gtm_server"]; !ok {
+		t.Fatal("Expected data source 'bigip_gtm_server' to be registered in the provider")
+	}
+}

--- a/bigip/datasource_bigip_gtm_server.go
+++ b/bigip/datasource_bigip_gtm_server.go
@@ -19,6 +19,12 @@ func dataSourceBigipGtmServer() *schema.Resource {
 				Required:    true,
 				Description: "Name of the GTM server",
 			},
+			"partition": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "Common",
+				Description: "Partition of the GTM server",
+			},
 			"datacenter": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -140,18 +146,20 @@ func dataSourceBigipGtmServerRead(ctx context.Context, d *schema.ResourceData, m
 	client := meta.(*bigip.BigIP)
 
 	name := d.Get("name").(string)
+	partition := d.Get("partition").(string)
+	fullPath := fmt.Sprintf("/%s/%s", partition, name)
 
-	log.Printf("[DEBUG] Reading GTM Server data source: %s", name)
+	log.Printf("[DEBUG] Reading GTM Server data source: %s", fullPath)
 
-	server, err := client.GetGtmserver(name)
+	server, err := client.GetGtmserver(fullPath)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error retrieving GTM Server %s: %v", name, err))
 	}
 	if server == nil {
-		return diag.FromErr(fmt.Errorf("GTM Server %s not found", name))
+		return diag.FromErr(fmt.Errorf("GTM Server %s not found", fullPath))
 	}
 
-	d.SetId(name)
+	d.SetId(fullPath)
 	d.Set("name", server.Name)
 	d.Set("datacenter", server.Datacenter)
 	d.Set("description", server.Description)

--- a/bigip/datasource_bigip_gtm_server.go
+++ b/bigip/datasource_bigip_gtm_server.go
@@ -1,0 +1,201 @@
+package bigip
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	bigip "github.com/f5devcentral/go-bigip"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceBigipGtmServer() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceBigipGtmServerRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the GTM server",
+			},
+			"datacenter": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Datacenter the server belongs to",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Description of the GTM server",
+			},
+			"product": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Server type (bigip, generic-host, etc.)",
+			},
+			"enabled": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the server is enabled",
+			},
+			"monitor": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Monitor assigned to the server",
+			},
+			"virtual_server_discovery": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Virtual server discovery mode",
+			},
+			"link_discovery": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Link discovery mode",
+			},
+			"prober_preference": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Prober preference",
+			},
+			"prober_fallback": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Prober fallback",
+			},
+			"prober_pool": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Prober pool",
+			},
+			"addresses": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "IP addresses for the server",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "IP address",
+						},
+						"device_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Device name for the address",
+						},
+						"translation": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "IP translation address",
+						},
+					},
+				},
+			},
+			"virtual_servers": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Virtual servers configured on the GTM server",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Name of the virtual server",
+						},
+						"destination": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Destination IP address and port",
+						},
+						"enabled": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Whether the virtual server is enabled",
+						},
+						"translation_address": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Translation IP address for NAT",
+						},
+						"translation_port": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Translation port for NAT",
+						},
+						"monitor": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Health monitor for this virtual server",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceBigipGtmServerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+
+	name := d.Get("name").(string)
+
+	log.Printf("[DEBUG] Reading GTM Server data source: %s", name)
+
+	server, err := client.GetGtmserver(name)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error retrieving GTM Server %s: %v", name, err))
+	}
+	if server == nil {
+		return diag.FromErr(fmt.Errorf("GTM Server %s not found", name))
+	}
+
+	d.SetId(name)
+	d.Set("name", server.Name)
+	d.Set("datacenter", server.Datacenter)
+	d.Set("description", server.Description)
+	d.Set("product", server.Product)
+	d.Set("enabled", server.Enabled)
+	d.Set("monitor", server.Monitor)
+	d.Set("virtual_server_discovery", server.Virtual_server_discovery)
+	d.Set("link_discovery", server.LinkDiscovery)
+	d.Set("prober_preference", server.ProberPreference)
+	d.Set("prober_fallback", server.ProberFallback)
+	d.Set("prober_pool", server.ProberPool)
+
+	// Handle addresses
+	if len(server.Addresses) > 0 {
+		addresses := make([]interface{}, len(server.Addresses))
+		for i, addr := range server.Addresses {
+			addresses[i] = map[string]interface{}{
+				"name":        addr.Name,
+				"device_name": addr.Device_name,
+				"translation": addr.Translation,
+			}
+		}
+		d.Set("addresses", addresses)
+	}
+
+	// Handle virtual servers
+	if len(server.GTMVirtual_Server) > 0 {
+		virtualServers := make([]interface{}, len(server.GTMVirtual_Server))
+		for i, vs := range server.GTMVirtual_Server {
+			translationAddr := vs.TranslationAddress
+			if translationAddr == "none" {
+				translationAddr = ""
+			}
+			virtualServers[i] = map[string]interface{}{
+				"name":                vs.Name,
+				"destination":         vs.Destination,
+				"enabled":             vs.Enabled,
+				"translation_address": translationAddr,
+				"translation_port":    vs.TranslationPort,
+				"monitor":             vs.Monitor,
+			}
+		}
+		d.Set("virtual_servers", virtualServers)
+	}
+
+	return nil
+}

--- a/bigip/datasource_bigip_gtm_server_test.go
+++ b/bigip/datasource_bigip_gtm_server_test.go
@@ -1,0 +1,39 @@
+//go:build unit
+// +build unit
+
+package bigip
+
+import (
+	"testing"
+)
+
+func TestDataSourceBigipGtmServerSchema(t *testing.T) {
+	ds := dataSourceBigipGtmServer()
+
+	if ds.ReadContext == nil {
+		t.Fatal("Expected ReadContext to be defined")
+	}
+
+	// name is the only required field (used to look up the server)
+	nameField, ok := ds.Schema["name"]
+	if !ok {
+		t.Fatal("Expected field 'name' to exist")
+	}
+	if !nameField.Required {
+		t.Error("Expected field 'name' to be required")
+	}
+
+	computedFields := []string{"datacenter", "description", "product", "enabled", "monitor",
+		"virtual_server_discovery", "link_discovery", "prober_preference", "prober_fallback",
+		"prober_pool", "addresses", "virtual_servers"}
+	for _, field := range computedFields {
+		s, ok := ds.Schema[field]
+		if !ok {
+			t.Errorf("Expected field '%s' to exist", field)
+			continue
+		}
+		if !s.Computed {
+			t.Errorf("Expected field '%s' to be computed", field)
+		}
+	}
+}

--- a/bigip/provider.go
+++ b/bigip/provider.go
@@ -127,6 +127,8 @@ func Provider() *schema.Provider {
 			"bigip_fast_azure_service_discovery":  dataSourceBigipFastAzureServiceDiscovery(),
 			"bigip_fast_gce_service_discovery":    dataSourceBigipFastGceServiceDiscovery(),
 			"bigip_as3_device_information":        dataSourceBigipAs3(),
+			"bigip_gtm_datacenter":                dataSourceBigipGtmDatacenter(),
+			"bigip_gtm_server":                    dataSourceBigipGtmServer(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"bigip_cm_device":                       resourceBigipCmDevice(),

--- a/docs/data-sources/bigip_gtm_datacenter.md
+++ b/docs/data-sources/bigip_gtm_datacenter.md
@@ -1,0 +1,49 @@
+---
+layout: "bigip"
+page_title: "BIG-IP: bigip_gtm_datacenter"
+subcategory: "Global Traffic Manager(GTM)"
+description: |-
+  Provides details about bigip_gtm_datacenter data source
+---
+
+# bigip\_gtm\_datacenter
+
+Use this data source (`bigip_gtm_datacenter`) to look up an existing GTM datacenter on the BIG-IP. This is useful when datacenters are shared across multiple Terraform workspaces and you need to reference them without managing them as resources.
+
+## Example Usage
+
+```hcl
+data "bigip_gtm_datacenter" "dc" {
+  name      = "my-datacenter"
+  partition = "Common"
+}
+
+output "datacenter_enabled" {
+  value = data.bigip_gtm_datacenter.dc.enabled
+}
+
+output "datacenter_location" {
+  value = data.bigip_gtm_datacenter.dc.location
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) Name of the GTM datacenter.
+* `partition` - (Required) Partition of the GTM datacenter.
+
+## Attributes Reference
+
+Additionally, the following attributes are exported:
+
+* `description` - Description of the datacenter.
+
+* `contact` - Contact information for the datacenter.
+
+* `enabled` - Whether the datacenter is enabled.
+
+* `location` - Location of the datacenter.
+
+* `prober_fallback` - Type of prober to use for fallback.
+
+* `prober_preference` - Type of prober to prefer.

--- a/docs/data-sources/bigip_gtm_server.md
+++ b/docs/data-sources/bigip_gtm_server.md
@@ -14,7 +14,8 @@ Use this data source (`bigip_gtm_server`) to look up an existing GTM server on t
 
 ```hcl
 data "bigip_gtm_server" "srv" {
-  name = "my-server"
+  name      = "my-server"
+  partition = "Common"
 }
 
 output "server_datacenter" {
@@ -33,6 +34,8 @@ output "server_addresses" {
 ## Argument Reference
 
 * `name` - (Required) Name of the GTM server.
+
+* `partition` - (Optional) Partition of the GTM server. Defaults to `Common`.
 
 ## Attributes Reference
 

--- a/docs/data-sources/bigip_gtm_server.md
+++ b/docs/data-sources/bigip_gtm_server.md
@@ -1,0 +1,72 @@
+---
+layout: "bigip"
+page_title: "BIG-IP: bigip_gtm_server"
+subcategory: "Global Traffic Manager(GTM)"
+description: |-
+  Provides details about bigip_gtm_server data source
+---
+
+# bigip\_gtm\_server
+
+Use this data source (`bigip_gtm_server`) to look up an existing GTM server on the BIG-IP. This is useful when servers are shared across multiple Terraform workspaces and you need to reference them without managing them as resources.
+
+## Example Usage
+
+```hcl
+data "bigip_gtm_server" "srv" {
+  name = "my-server"
+}
+
+output "server_datacenter" {
+  value = data.bigip_gtm_server.srv.datacenter
+}
+
+output "server_product" {
+  value = data.bigip_gtm_server.srv.product
+}
+
+output "server_addresses" {
+  value = data.bigip_gtm_server.srv.addresses
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) Name of the GTM server.
+
+## Attributes Reference
+
+Additionally, the following attributes are exported:
+
+* `datacenter` - Datacenter the server belongs to.
+
+* `description` - Description of the GTM server.
+
+* `product` - Server type (bigip, generic-host, etc.).
+
+* `enabled` - Whether the server is enabled.
+
+* `monitor` - Monitor assigned to the server.
+
+* `virtual_server_discovery` - Virtual server discovery mode.
+
+* `link_discovery` - Link discovery mode.
+
+* `prober_preference` - Prober preference.
+
+* `prober_fallback` - Prober fallback.
+
+* `prober_pool` - Prober pool.
+
+* `addresses` - IP addresses for the server. Each address contains:
+  * `name` - IP address.
+  * `device_name` - Device name for the address.
+  * `translation` - IP translation address.
+
+* `virtual_servers` - Virtual servers configured on the GTM server. Each virtual server contains:
+  * `name` - Name of the virtual server.
+  * `destination` - Destination IP address and port.
+  * `enabled` - Whether the virtual server is enabled.
+  * `translation_address` - Translation IP address for NAT.
+  * `translation_port` - Translation port for NAT.
+  * `monitor` - Health monitor for this virtual server.


### PR DESCRIPTION
Customers managing GTM infrastructure across multiple Terraform workspaces have no way to reference existing GTM datacenters or servers without importing them as fully managed resources. This is problematic because these objects are typically shared — a datacenter or generic-host server is created once and consumed by many teams or workspaces. Without data sources, users are forced to either hardcode values, manage the same resource in multiple workspaces (risking conflicts), or use unsafe workarounds like `terraform import` into every workspace that needs a reference.

### Solution

Added two new read-only data sources:

- **`bigip_gtm_datacenter`** — Looks up an existing GTM datacenter by `name` and `partition`, exposing `description`, `contact`, `enabled`, `location`, `prober_fallback`, and `prober_preference` as computed attributes.

- **`bigip_gtm_server`** — Looks up an existing GTM server by `name`, exposing `datacenter`, `description`, `product`, `enabled`, `monitor`, `virtual_server_discovery`, `link_discovery`, `prober_preference`, `prober_fallback`, `prober_pool`, `addresses`, and `virtual_servers` as computed attributes.

Both data sources reuse the existing SDK methods (`GetGTMDatacenter`, `GetGtmserver`) with no changes to the underlying API layer.

### Example Usage

```hcl
data "bigip_gtm_datacenter" "dc" {
  name      = "my-datacenter"
  partition = "Common"
}

data "bigip_gtm_server" "srv" {
  name = "my-server"
}

output "server_datacenter" {
  value = data.bigip_gtm_server.srv.datacenter
}
