### PR TITLE
feat: add GTM topology record and region resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
  - Added `pools` attribute to `bigip_gtm_wideip` resource for associating GTM pools with a WideIP
  - Added `bigip_gtm_datacenter` data source for reading existing GTM datacenters
  - Added `bigip_gtm_server` data source for reading existing GTM servers
+ - Added `bigip_gtm_topology_region` resource for managing GTM topology regions (subnets, countries, states, datacenters, etc.)
+ - Added `bigip_gtm_topology_record` resource for managing GTM topology-based routing rules
 
 ## 1.3.0 (July 23, 2020)
 

--- a/bigip/provider.go
+++ b/bigip/provider.go
@@ -203,6 +203,8 @@ func Provider() *schema.Provider {
 			"bigip_ltm_profile_rewrite_uri_rules":   resourceBigipLtmRewriteProfileUriRules(),
 			"bigip_saas_bot_defense_profile":        resourceBigipSaasBotDefenseProfile(),
 			"bigip_gtm_wideip":                      resourceBigipGtmWideip(),
+			"bigip_gtm_topology_record":             resourceBigipGtmTopologyRecord(),
+			"bigip_gtm_topology_region":             resourceBigipGtmTopologyRegion(),
 			"bigip_gtm_pool":                        resourceBigipGtmPool(),
 			"bigip_gtm_datacenter":                  resourceBigipGtmDatacenter(),
 			"bigip_gtm_server":                      resourceBigipGtmServer(),

--- a/bigip/resource_bigip_gtm_topology_record.go
+++ b/bigip/resource_bigip_gtm_topology_record.go
@@ -1,0 +1,128 @@
+package bigip
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	bigip "github.com/f5devcentral/go-bigip"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceBigipGtmTopologyRecord() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBigipGtmTopologyRecordCreate,
+		ReadContext:   resourceBigipGtmTopologyRecordRead,
+		UpdateContext: resourceBigipGtmTopologyRecordUpdate,
+		DeleteContext: resourceBigipGtmTopologyRecordDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"description": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The topology record description that defines the source and destination match. Format: 'ldns: <source> server: <destination>' (e.g., 'ldns: region /Common/my-region server: datacenter /Common/my-dc')",
+			},
+			"order": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     0,
+				Description: "The order in which the topology record is evaluated",
+			},
+			"score": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     1,
+				Description: "The weight or preference given to this topology record",
+			},
+		},
+	}
+}
+
+func resourceBigipGtmTopologyRecordCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+
+	description := d.Get("description").(string)
+
+	log.Printf("[INFO] Creating GTM Topology Record: %s", description)
+
+	config := &bigip.GTMTopologyRecord{
+		Description: description,
+		Order:       d.Get("order").(int),
+		Score:       d.Get("score").(int),
+	}
+
+	err := client.CreateGTMTopologyRecord(config)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error creating GTM Topology Record: %v", err))
+	}
+
+	d.SetId(description)
+
+	return resourceBigipGtmTopologyRecordRead(ctx, d, meta)
+}
+
+func resourceBigipGtmTopologyRecordRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+
+	description := d.Id()
+
+	log.Printf("[INFO] Reading GTM Topology Record: %s", description)
+
+	record, err := client.GetGTMTopologyRecord(description)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error retrieving GTM Topology Record: %v", err))
+	}
+	if record == nil {
+		log.Printf("[WARN] GTM Topology Record not found, removing from state")
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("description", record.Description)
+	d.Set("order", record.Order)
+	d.Set("score", record.Score)
+
+	return nil
+}
+
+func resourceBigipGtmTopologyRecordUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+
+	description := d.Id()
+
+	log.Printf("[INFO] Updating GTM Topology Record: %s", description)
+
+	config := &bigip.GTMTopologyRecord{
+		Description: description,
+		Order:       d.Get("order").(int),
+		Score:       d.Get("score").(int),
+	}
+
+	err := client.ModifyGTMTopologyRecord(description, config)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error updating GTM Topology Record: %v", err))
+	}
+
+	return resourceBigipGtmTopologyRecordRead(ctx, d, meta)
+}
+
+func resourceBigipGtmTopologyRecordDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+
+	description := d.Id()
+
+	log.Printf("[INFO] Deleting GTM Topology Record: %s", description)
+
+	err := client.DeleteGTMTopologyRecord(description)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error deleting GTM Topology Record: %v", err))
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/bigip/resource_bigip_gtm_topology_region.go
+++ b/bigip/resource_bigip_gtm_topology_region.go
@@ -143,17 +143,17 @@ func resourceBigipGtmTopologyRegionUpdate(ctx context.Context, d *schema.Resourc
 		Partition: d.Get("partition").(string),
 	}
 
-	if v, ok := d.GetOk("members"); ok {
-		membersSet := v.(*schema.Set)
-		members := make([]bigip.GTMRegionMember, 0, membersSet.Len())
-		for _, item := range membersSet.List() {
-			memberMap := item.(map[string]interface{})
-			members = append(members, bigip.GTMRegionMember{
-				Name: memberMap["name"].(string),
-			})
-		}
-		config.Members = members
+	// Always set members so that removing all members from config sends an
+	// empty list to the API instead of silently preserving the old value.
+	membersSet := d.Get("members").(*schema.Set)
+	members := make([]bigip.GTMRegionMember, 0, membersSet.Len())
+	for _, item := range membersSet.List() {
+		memberMap := item.(map[string]interface{})
+		members = append(members, bigip.GTMRegionMember{
+			Name: memberMap["name"].(string),
+		})
 	}
+	config.Members = members
 
 	err := client.ModifyGTMRegion(fullPath, config)
 	if err != nil {

--- a/bigip/resource_bigip_gtm_topology_region.go
+++ b/bigip/resource_bigip_gtm_topology_region.go
@@ -1,0 +1,180 @@
+package bigip
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	bigip "github.com/f5devcentral/go-bigip"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceBigipGtmTopologyRegion() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBigipGtmTopologyRegionCreate,
+		ReadContext:   resourceBigipGtmTopologyRegionRead,
+		UpdateContext: resourceBigipGtmTopologyRegionUpdate,
+		DeleteContext: resourceBigipGtmTopologyRegionDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Name of the GTM topology region",
+			},
+			"partition": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "Common",
+				ForceNew:    true,
+				Description: "Partition of the GTM topology region",
+			},
+			"members": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Region member entry. Examples: 'subnet 10.0.0.0/8', 'country US', 'state US/California', 'datacenter /Common/my-dc', 'isp Comcast', 'region /Common/other-region', 'continent NA', 'pool /Common/my-pool'",
+						},
+					},
+				},
+				Description: "The members that define this topology region (subnets, countries, states, datacenters, ISPs, etc.)",
+			},
+		},
+	}
+}
+
+func resourceBigipGtmTopologyRegionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+
+	name := d.Get("name").(string)
+	partition := d.Get("partition").(string)
+	fullPath := fmt.Sprintf("/%s/%s", partition, name)
+
+	log.Printf("[INFO] Creating GTM Topology Region: %s", fullPath)
+
+	config := &bigip.GTMRegion{
+		Name:      name,
+		Partition: partition,
+	}
+
+	if v, ok := d.GetOk("members"); ok {
+		membersSet := v.(*schema.Set)
+		members := make([]bigip.GTMRegionMember, 0, membersSet.Len())
+		for _, item := range membersSet.List() {
+			memberMap := item.(map[string]interface{})
+			members = append(members, bigip.GTMRegionMember{
+				Name: memberMap["name"].(string),
+			})
+		}
+		config.Members = members
+	}
+
+	err := client.CreateGTMRegion(config)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error creating GTM Topology Region %s: %v", fullPath, err))
+	}
+
+	d.SetId(fullPath)
+
+	return resourceBigipGtmTopologyRegionRead(ctx, d, meta)
+}
+
+func resourceBigipGtmTopologyRegionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+
+	fullPath := d.Id()
+
+	log.Printf("[INFO] Reading GTM Topology Region: %s", fullPath)
+
+	region, err := client.GetGTMRegion(fullPath)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error retrieving GTM Topology Region %s: %v", fullPath, err))
+	}
+	if region == nil {
+		log.Printf("[WARN] GTM Topology Region %s not found, removing from state", fullPath)
+		d.SetId("")
+		return nil
+	}
+
+	// Parse partition and name from fullPath
+	parts := strings.Split(strings.TrimPrefix(fullPath, "/"), "/")
+	if len(parts) >= 2 {
+		d.Set("partition", parts[0])
+		d.Set("name", parts[1])
+	} else {
+		d.Set("name", region.Name)
+		if region.Partition != "" {
+			d.Set("partition", region.Partition)
+		}
+	}
+
+	if len(region.Members) > 0 {
+		members := make([]interface{}, 0, len(region.Members))
+		for _, member := range region.Members {
+			members = append(members, map[string]interface{}{
+				"name": member.Name,
+			})
+		}
+		d.Set("members", members)
+	}
+
+	return nil
+}
+
+func resourceBigipGtmTopologyRegionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+
+	fullPath := d.Id()
+
+	log.Printf("[INFO] Updating GTM Topology Region: %s", fullPath)
+
+	config := &bigip.GTMRegion{
+		Name:      d.Get("name").(string),
+		Partition: d.Get("partition").(string),
+	}
+
+	if v, ok := d.GetOk("members"); ok {
+		membersSet := v.(*schema.Set)
+		members := make([]bigip.GTMRegionMember, 0, membersSet.Len())
+		for _, item := range membersSet.List() {
+			memberMap := item.(map[string]interface{})
+			members = append(members, bigip.GTMRegionMember{
+				Name: memberMap["name"].(string),
+			})
+		}
+		config.Members = members
+	}
+
+	err := client.ModifyGTMRegion(fullPath, config)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error updating GTM Topology Region %s: %v", fullPath, err))
+	}
+
+	return resourceBigipGtmTopologyRegionRead(ctx, d, meta)
+}
+
+func resourceBigipGtmTopologyRegionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*bigip.BigIP)
+
+	fullPath := d.Id()
+
+	log.Printf("[INFO] Deleting GTM Topology Region: %s", fullPath)
+
+	err := client.DeleteGTMRegion(fullPath)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error deleting GTM Topology Region %s: %v", fullPath, err))
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/bigip/resource_bigip_gtm_topology_test.go
+++ b/bigip/resource_bigip_gtm_topology_test.go
@@ -1,0 +1,292 @@
+//go:build unit
+// +build unit
+
+package bigip
+
+import (
+	"encoding/json"
+	"testing"
+
+	bigip "github.com/f5devcentral/go-bigip"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// TestResourceBigipGtmTopologyRecordExists proves that the bigip_gtm_topology_record
+// resource is registered in the provider.
+func TestResourceBigipGtmTopologyRecordExists(t *testing.T) {
+	p := Provider()
+
+	if _, ok := p.ResourcesMap["bigip_gtm_topology_record"]; !ok {
+		t.Fatal("Expected resource 'bigip_gtm_topology_record' to be registered in the provider")
+	}
+}
+
+// TestResourceBigipGtmTopologyRegionExists proves that the bigip_gtm_topology_region
+// resource is registered in the provider.
+func TestResourceBigipGtmTopologyRegionExists(t *testing.T) {
+	p := Provider()
+
+	if _, ok := p.ResourcesMap["bigip_gtm_topology_region"]; !ok {
+		t.Fatal("Expected resource 'bigip_gtm_topology_region' to be registered in the provider")
+	}
+}
+
+func TestResourceBigipGtmTopologyRecordSchema(t *testing.T) {
+	resource := resourceBigipGtmTopologyRecord()
+
+	if resource.CreateContext == nil {
+		t.Error("Expected CreateContext to be defined")
+	}
+	if resource.ReadContext == nil {
+		t.Error("Expected ReadContext to be defined")
+	}
+	if resource.UpdateContext == nil {
+		t.Error("Expected UpdateContext to be defined")
+	}
+	if resource.DeleteContext == nil {
+		t.Error("Expected DeleteContext to be defined")
+	}
+
+	// description is required and ForceNew
+	descField, ok := resource.Schema["description"]
+	if !ok {
+		t.Fatal("Expected 'description' field to exist")
+	}
+	if !descField.Required {
+		t.Error("Expected 'description' to be required")
+	}
+	if !descField.ForceNew {
+		t.Error("Expected 'description' to be ForceNew")
+	}
+
+	// order is optional with default 0
+	orderField, ok := resource.Schema["order"]
+	if !ok {
+		t.Fatal("Expected 'order' field to exist")
+	}
+	if orderField.Type != schema.TypeInt {
+		t.Errorf("Expected 'order' to be TypeInt, got %v", orderField.Type)
+	}
+	if orderField.Default != 0 {
+		t.Errorf("Expected 'order' default to be 0, got %v", orderField.Default)
+	}
+
+	// score is optional with default 1
+	scoreField, ok := resource.Schema["score"]
+	if !ok {
+		t.Fatal("Expected 'score' field to exist")
+	}
+	if scoreField.Type != schema.TypeInt {
+		t.Errorf("Expected 'score' to be TypeInt, got %v", scoreField.Type)
+	}
+	if scoreField.Default != 1 {
+		t.Errorf("Expected 'score' default to be 1, got %v", scoreField.Default)
+	}
+}
+
+func TestResourceBigipGtmTopologyRegionSchema(t *testing.T) {
+	resource := resourceBigipGtmTopologyRegion()
+
+	if resource.CreateContext == nil {
+		t.Error("Expected CreateContext to be defined")
+	}
+	if resource.ReadContext == nil {
+		t.Error("Expected ReadContext to be defined")
+	}
+	if resource.UpdateContext == nil {
+		t.Error("Expected UpdateContext to be defined")
+	}
+	if resource.DeleteContext == nil {
+		t.Error("Expected DeleteContext to be defined")
+	}
+
+	// name is required and ForceNew
+	nameField, ok := resource.Schema["name"]
+	if !ok {
+		t.Fatal("Expected 'name' field to exist")
+	}
+	if !nameField.Required {
+		t.Error("Expected 'name' to be required")
+	}
+	if !nameField.ForceNew {
+		t.Error("Expected 'name' to be ForceNew")
+	}
+
+	// partition is optional with default Common
+	partField, ok := resource.Schema["partition"]
+	if !ok {
+		t.Fatal("Expected 'partition' field to exist")
+	}
+	if partField.Default != "Common" {
+		t.Errorf("Expected 'partition' default to be 'Common', got %v", partField.Default)
+	}
+
+	// members is optional TypeSet with nested name field
+	membersField, ok := resource.Schema["members"]
+	if !ok {
+		t.Fatal("Expected 'members' field to exist")
+	}
+	if membersField.Type != schema.TypeSet {
+		t.Errorf("Expected 'members' to be TypeSet, got %v", membersField.Type)
+	}
+	memberElem, ok := membersField.Elem.(*schema.Resource)
+	if !ok {
+		t.Fatal("Expected 'members' Elem to be a *schema.Resource")
+	}
+	memberName, ok := memberElem.Schema["name"]
+	if !ok {
+		t.Fatal("Expected 'members.name' field to exist")
+	}
+	if !memberName.Required {
+		t.Error("Expected 'members.name' to be required")
+	}
+	if memberName.Type != schema.TypeString {
+		t.Errorf("Expected 'members.name' to be TypeString, got %v", memberName.Type)
+	}
+}
+
+func TestGTMTopologyRecordMarshalJSON(t *testing.T) {
+	record := bigip.GTMTopologyRecord{
+		Description: "ldns: region /Common/east-coast server: datacenter /Common/dc1",
+		Order:       1,
+		Score:       100,
+	}
+
+	data, err := json.Marshal(record)
+	if err != nil {
+		t.Fatalf("Failed to marshal GTMTopologyRecord: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	if result["description"] != "ldns: region /Common/east-coast server: datacenter /Common/dc1" {
+		t.Errorf("Expected description to match, got '%v'", result["description"])
+	}
+	if int(result["order"].(float64)) != 1 {
+		t.Errorf("Expected order 1, got %v", result["order"])
+	}
+	if int(result["score"].(float64)) != 100 {
+		t.Errorf("Expected score 100, got %v", result["score"])
+	}
+}
+
+func TestGTMTopologyRecordUnmarshalJSON(t *testing.T) {
+	jsonData := `{
+		"name": "ldns: region /Common/east-coast server: datacenter /Common/dc1",
+		"description": "ldns: region /Common/east-coast server: datacenter /Common/dc1",
+		"order": 2,
+		"score": 50
+	}`
+
+	var record bigip.GTMTopologyRecord
+	if err := json.Unmarshal([]byte(jsonData), &record); err != nil {
+		t.Fatalf("Failed to unmarshal GTMTopologyRecord: %v", err)
+	}
+
+	if record.Description != "ldns: region /Common/east-coast server: datacenter /Common/dc1" {
+		t.Errorf("Expected description match, got '%s'", record.Description)
+	}
+	if record.Order != 2 {
+		t.Errorf("Expected order 2, got %d", record.Order)
+	}
+	if record.Score != 50 {
+		t.Errorf("Expected score 50, got %d", record.Score)
+	}
+}
+
+func TestGTMRegionMarshalJSON(t *testing.T) {
+	region := bigip.GTMRegion{
+		Name:      "east-coast",
+		Partition: "Common",
+		Members: []bigip.GTMRegionMember{
+			{Name: "subnet 10.0.0.0/8"},
+			{Name: "state US/New-York"},
+		},
+	}
+
+	data, err := json.Marshal(region)
+	if err != nil {
+		t.Fatalf("Failed to marshal GTMRegion: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	if result["name"] != "east-coast" {
+		t.Errorf("Expected name 'east-coast', got '%v'", result["name"])
+	}
+
+	members, ok := result["regionMembers"]
+	if !ok {
+		t.Fatal("Expected 'regionMembers' key in marshalled JSON")
+	}
+
+	membersArr := members.([]interface{})
+	if len(membersArr) != 2 {
+		t.Fatalf("Expected 2 members, got %d", len(membersArr))
+	}
+
+	first := membersArr[0].(map[string]interface{})
+	if first["name"] != "subnet 10.0.0.0/8" {
+		t.Errorf("Expected first member 'subnet 10.0.0.0/8', got '%v'", first["name"])
+	}
+}
+
+func TestGTMRegionUnmarshalJSON(t *testing.T) {
+	jsonData := `{
+		"name": "east-coast",
+		"partition": "Common",
+		"fullPath": "/Common/east-coast",
+		"regionMembers": [
+			{"name": "subnet 10.0.0.0/8"},
+			{"name": "country US"}
+		]
+	}`
+
+	var region bigip.GTMRegion
+	if err := json.Unmarshal([]byte(jsonData), &region); err != nil {
+		t.Fatalf("Failed to unmarshal GTMRegion: %v", err)
+	}
+
+	if region.Name != "east-coast" {
+		t.Errorf("Expected name 'east-coast', got '%s'", region.Name)
+	}
+	if region.Partition != "Common" {
+		t.Errorf("Expected partition 'Common', got '%s'", region.Partition)
+	}
+	if len(region.Members) != 2 {
+		t.Fatalf("Expected 2 members, got %d", len(region.Members))
+	}
+	if region.Members[0].Name != "subnet 10.0.0.0/8" {
+		t.Errorf("Expected first member 'subnet 10.0.0.0/8', got '%s'", region.Members[0].Name)
+	}
+	if region.Members[1].Name != "country US" {
+		t.Errorf("Expected second member 'country US', got '%s'", region.Members[1].Name)
+	}
+}
+
+func TestGTMRegionEmptyMembersOmittedFromJSON(t *testing.T) {
+	region := bigip.GTMRegion{
+		Name:      "empty-region",
+		Partition: "Common",
+	}
+
+	data, err := json.Marshal(region)
+	if err != nil {
+		t.Fatalf("Failed to marshal GTMRegion without members: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	if _, ok := result["regionMembers"]; ok {
+		t.Error("Expected 'regionMembers' to be omitted from JSON when empty")
+	}
+}

--- a/docs/resources/bigip_gtm_topology_record.md
+++ b/docs/resources/bigip_gtm_topology_record.md
@@ -1,0 +1,99 @@
+# bigip_gtm_topology_record
+
+Manages F5 BIG-IP GTM (Global Traffic Manager) Topology Record resources.
+
+A GTM topology record defines a routing rule for topology-based load balancing. Each record matches a source (LDNS) to a destination (server, datacenter, or pool) with an associated score. When the GTM pool load balancing mode is set to `topology`, these records determine how DNS queries are routed based on the geographic or network location of the requesting LDNS.
+
+## Example Usage
+
+### Route a Region to a Datacenter
+
+```hcl
+resource "bigip_gtm_topology_record" "east_to_dc1" {
+  description = "ldns: region /Common/east-coast server: datacenter /Common/dc1"
+  order       = 1
+  score       = 100
+}
+```
+
+### Route a Subnet to a Pool
+
+```hcl
+resource "bigip_gtm_topology_record" "internal_to_pool" {
+  description = "ldns: subnet 10.0.0.0/8 server: pool /Common/internal-pool"
+  order       = 2
+  score       = 50
+}
+```
+
+### Route a Country to a Datacenter
+
+```hcl
+resource "bigip_gtm_topology_record" "us_to_us_dc" {
+  description = "ldns: country US server: datacenter /Common/us-datacenter"
+  order       = 3
+  score       = 75
+}
+```
+
+### Using with Topology Regions
+
+```hcl
+resource "bigip_gtm_topology_region" "east_coast" {
+  name      = "east-coast"
+  partition = "Common"
+
+  members {
+    name = "state US/New-York"
+  }
+
+  members {
+    name = "state US/Virginia"
+  }
+}
+
+resource "bigip_gtm_topology_record" "east_to_dc1" {
+  description = "ldns: region /Common/east-coast server: datacenter /Common/dc1"
+  order       = 1
+  score       = 100
+
+  depends_on = [bigip_gtm_topology_region.east_coast]
+}
+```
+
+## Argument Reference
+
+* `description` - (Required) The topology record description that defines the source and destination match. This follows the BIG-IP format: `ldns: <source> server: <destination>`. Cannot be changed after creation. Valid source/destination types include:
+  - `region <path>` - e.g., `region /Common/east-coast`
+  - `datacenter <path>` - e.g., `datacenter /Common/dc1`
+  - `pool <path>` - e.g., `pool /Common/my-pool`
+  - `subnet <cidr>` - e.g., `subnet 10.0.0.0/8`
+  - `country <code>` - e.g., `country US`
+  - `state <country>/<state>` - e.g., `state US/California`
+  - `continent <code>` - e.g., `continent NA`
+  - `isp <name>` - e.g., `isp Comcast`
+
+* `order` - (Optional) The order in which the topology record is evaluated. Lower values are evaluated first. Default is `0`.
+
+* `score` - (Optional) The weight or preference given to this topology record. Higher scores indicate stronger preference. Default is `1`.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `id` - The description string of the topology record.
+
+## Import
+
+GTM topology records can be imported using the description string, e.g.
+
+```
+terraform import bigip_gtm_topology_record.example "ldns: region /Common/east-coast server: datacenter /Common/dc1"
+```
+
+## Notes
+
+* Topology records are evaluated in order. Use the `order` field to control evaluation priority.
+* The `description` field cannot be changed after creation. To modify the source/destination match, destroy and recreate the record.
+* Regions referenced in topology records must exist before the record is created. Use `depends_on` to enforce ordering.
+* Topology records are only effective when a WideIP's `pool_lb_mode` is set to `topology`.

--- a/docs/resources/bigip_gtm_topology_region.md
+++ b/docs/resources/bigip_gtm_topology_region.md
@@ -1,0 +1,107 @@
+# bigip_gtm_topology_region
+
+Manages F5 BIG-IP GTM (Global Traffic Manager) Topology Region resources.
+
+A GTM topology region is a named group of network locations used in topology-based load balancing. Regions can contain subnets, countries, states, continents, datacenters, ISPs, or references to other regions. They are referenced by topology records to define source-to-destination routing preferences.
+
+## Example Usage
+
+### Region with Subnets
+
+```hcl
+resource "bigip_gtm_topology_region" "internal" {
+  name      = "internal-networks"
+  partition = "Common"
+
+  members {
+    name = "subnet 10.0.0.0/8"
+  }
+
+  members {
+    name = "subnet 172.16.0.0/12"
+  }
+
+  members {
+    name = "subnet 192.168.0.0/16"
+  }
+}
+```
+
+### Region with Geographic Locations
+
+```hcl
+resource "bigip_gtm_topology_region" "east_coast" {
+  name      = "east-coast"
+  partition = "Common"
+
+  members {
+    name = "state US/New-York"
+  }
+
+  members {
+    name = "state US/Virginia"
+  }
+
+  members {
+    name = "state US/Massachusetts"
+  }
+}
+```
+
+### Region with Mixed Member Types
+
+```hcl
+resource "bigip_gtm_topology_region" "primary_dc" {
+  name      = "primary-region"
+  partition = "Common"
+
+  members {
+    name = "datacenter /Common/dc1"
+  }
+
+  members {
+    name = "subnet 10.10.0.0/16"
+  }
+
+  members {
+    name = "country US"
+  }
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) Name of the GTM topology region. Cannot be changed after creation.
+
+* `partition` - (Optional) Partition in which to create the region. Default is `Common`. Cannot be changed after creation.
+
+* `members` - (Optional) The members that define this topology region. Each member is a block containing:
+  * `name` - (Required) The member definition string. Valid formats include:
+    - `subnet <cidr>` - e.g., `subnet 10.0.0.0/8`
+    - `country <code>` - e.g., `country US`
+    - `state <country>/<state>` - e.g., `state US/California`
+    - `continent <code>` - e.g., `continent NA`
+    - `datacenter <path>` - e.g., `datacenter /Common/my-dc`
+    - `isp <name>` - e.g., `isp Comcast`
+    - `region <path>` - e.g., `region /Common/other-region`
+    - `pool <path>` - e.g., `pool /Common/my-pool`
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `id` - The full path of the region (e.g., `/Common/east-coast`)
+
+## Import
+
+GTM topology regions can be imported using the full path, e.g.
+
+```
+terraform import bigip_gtm_topology_region.example /Common/east-coast
+```
+
+## Notes
+
+* Regions must be created before they can be referenced in topology records.
+* A region can reference other regions as members, enabling hierarchical grouping.
+* The `name` and `partition` cannot be changed after creation. You must destroy and recreate the resource to change these values.

--- a/vendor/github.com/f5devcentral/go-bigip/gtm.go
+++ b/vendor/github.com/f5devcentral/go-bigip/gtm.go
@@ -22,6 +22,8 @@ const (
 	uriGtmmonitor = "monitor"
 	uriPoolA      = "pool/a"
 	uriWideIp     = "wideip"
+	uriTopology   = "topology"
+	uriRegion     = "region"
 )
 
 type Datacenters struct {
@@ -740,6 +742,92 @@ func (b *BigIP) ModifyGTMDatacenter(fullPath string, config *GTMDatacenter) erro
 // DeleteGTMDatacenter removes a GTM datacenter
 func (b *BigIP) DeleteGTMDatacenter(fullPath string) error {
 	return b.delete(uriGtm, uriDatacenter, fullPath)
+}
+
+// GTMTopologyRecord represents a GTM topology record
+type GTMTopologyRecord struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	Order       int    `json:"order,omitempty"`
+	Score       int    `json:"score,omitempty"`
+}
+
+type GTMTopologyRecords struct {
+	Items []GTMTopologyRecord `json:"items"`
+}
+
+// GTMRegion represents a GTM topology region
+type GTMRegion struct {
+	Name       string            `json:"name,omitempty"`
+	Partition  string            `json:"partition,omitempty"`
+	FullPath   string            `json:"fullPath,omitempty"`
+	Generation int               `json:"generation,omitempty"`
+	Members    []GTMRegionMember `json:"regionMembers,omitempty"`
+}
+
+type GTMRegions struct {
+	Items []GTMRegion `json:"items"`
+}
+
+// GTMRegionMember represents a member entry in a GTM region
+type GTMRegionMember struct {
+	Name string `json:"name,omitempty"`
+}
+
+// CreateGTMTopologyRecord creates a new GTM topology record
+func (b *BigIP) CreateGTMTopologyRecord(config *GTMTopologyRecord) error {
+	return b.post(config, uriGtm, uriTopology)
+}
+
+// GetGTMTopologyRecord retrieves a GTM topology record by its description
+func (b *BigIP) GetGTMTopologyRecord(description string) (*GTMTopologyRecord, error) {
+	var record GTMTopologyRecord
+	err, ok := b.getForEntity(&record, uriGtm, uriTopology, description)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+	return &record, nil
+}
+
+// ModifyGTMTopologyRecord updates a GTM topology record
+func (b *BigIP) ModifyGTMTopologyRecord(description string, config *GTMTopologyRecord) error {
+	return b.put(config, uriGtm, uriTopology, description)
+}
+
+// DeleteGTMTopologyRecord removes a GTM topology record
+func (b *BigIP) DeleteGTMTopologyRecord(description string) error {
+	return b.delete(uriGtm, uriTopology, description)
+}
+
+// CreateGTMRegion creates a new GTM topology region
+func (b *BigIP) CreateGTMRegion(config *GTMRegion) error {
+	return b.post(config, uriGtm, uriRegion)
+}
+
+// GetGTMRegion retrieves a GTM topology region by full path
+func (b *BigIP) GetGTMRegion(fullPath string) (*GTMRegion, error) {
+	var region GTMRegion
+	err, ok := b.getForEntity(&region, uriGtm, uriRegion, fullPath)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+	return &region, nil
+}
+
+// ModifyGTMRegion updates a GTM topology region
+func (b *BigIP) ModifyGTMRegion(fullPath string, config *GTMRegion) error {
+	return b.put(config, uriGtm, uriRegion, fullPath)
+}
+
+// DeleteGTMRegion removes a GTM topology region
+func (b *BigIP) DeleteGTMRegion(fullPath string) error {
+	return b.delete(uriGtm, uriRegion, fullPath)
 }
 
 // func (b *BigIP) GetDatacenters() (*GTMDatacenter, error) {

--- a/vendor/github.com/f5devcentral/go-bigip/gtm.go
+++ b/vendor/github.com/f5devcentral/go-bigip/gtm.go
@@ -748,8 +748,8 @@ func (b *BigIP) DeleteGTMDatacenter(fullPath string) error {
 type GTMTopologyRecord struct {
 	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
-	Order       int    `json:"order,omitempty"`
-	Score       int    `json:"score,omitempty"`
+	Order       int    `json:"order"`
+	Score       int    `json:"score"`
 }
 
 type GTMTopologyRecords struct {
@@ -762,7 +762,7 @@ type GTMRegion struct {
 	Partition  string            `json:"partition,omitempty"`
 	FullPath   string            `json:"fullPath,omitempty"`
 	Generation int               `json:"generation,omitempty"`
-	Members    []GTMRegionMember `json:"regionMembers,omitempty"`
+	Members    []GTMRegionMember `json:"regionMembers"`
 }
 
 type GTMRegions struct {


### PR DESCRIPTION
### Problem

Customers using GTM topology-based load balancing have no way to manage topology records or topology regions through Terraform. Topology records define routing rules (e.g., "if the LDNS is in region X, prefer server/pool Y"), and topology regions group network locations (subnets, countries, datacenters, etc.) into named sets. Without these resources, customers must manage topology configuration manually via tmsh or the GUI, breaking the infrastructure-as-code workflow.

### Solution

Added two new resources:

- **`bigip_gtm_topology_region`** — Manages named GTM topology regions. Regions contain members that define network locations using subnets, countries, states, continents, datacenters, ISPs, or references to other regions. Supports full CRUD and import.

- **`bigip_gtm_topology_record`** — Manages GTM topology records that define source-to-destination routing preferences. Each record uses a description string in the BIG-IP format (`ldns: <source> server: <destination>`) with an order and score. Supports full CRUD and import.

Both resources are backed by new SDK methods for the `/mgmt/tm/gtm/region` and `/mgmt/tm/gtm/topology` API endpoints.

### Example Usage

```hcl
resource "bigip_gtm_topology_region" "east_coast" {
  name      = "east-coast"
  partition = "Common"

  members {
    name = "subnet 10.0.0.0/8"
  }

  members {
    name = "state US/New-York"
  }
}

resource "bigip_gtm_topology_record" "east_to_dc1" {
  description = "ldns: region /Common/east-coast server: datacenter /Common/dc1"
  order       = 1
  score       = 100
}
