### PR TITLE
Fix clearing all records on an existing bigip_ltm_datagroup (#1164)

### DIFF
--- a/bigip/resource_bigip_ltm_datagroup.go
+++ b/bigip/resource_bigip_ltm_datagroup.go
@@ -87,14 +87,10 @@ func resourceBigipLtmDataGroupCreate(ctx context.Context, d *schema.ResourceData
 	name = d.Get("name").(string)
 	log.Printf("[DEBUG] Creating Data Group List %s", name)
 	if d.Get("internal").(bool) {
-		var records []bigip.DataGroupRecord
-		if rs.Len() > 0 {
-			for _, r := range rs.List() {
-				record := r.(map[string]interface{})
-				records = append(records, bigip.DataGroupRecord{Name: record["name"].(string), Data: record["data"].(string)})
-			}
-		} else {
-			records = nil
+		records := []bigip.DataGroupRecord{}
+		for _, r := range rs.List() {
+			record := r.(map[string]interface{})
+			records = append(records, bigip.DataGroupRecord{Name: record["name"].(string), Data: record["data"].(string)})
 		}
 		dg := &bigip.DataGroup{
 			Name:    name,
@@ -173,14 +169,10 @@ func resourceBigipLtmDataGroupUpdate(ctx context.Context, d *schema.ResourceData
 	dgtype := d.Get("type").(string)
 
 	if d.Get("internal").(bool) {
-		var records []bigip.DataGroupRecord
-		if rs.Len() > 0 {
-			for _, r := range rs.List() {
-				record := r.(map[string]interface{})
-				records = append(records, bigip.DataGroupRecord{Name: record["name"].(string), Data: record["data"].(string)})
-			}
-		} else {
-			records = nil
+		records := []bigip.DataGroupRecord{}
+		for _, r := range rs.List() {
+			record := r.(map[string]interface{})
+			records = append(records, bigip.DataGroupRecord{Name: record["name"].(string), Data: record["data"].(string)})
 		}
 
 		dgver := &bigip.DataGroup{

--- a/bigip/resource_bigip_ltm_datagroup_test.go
+++ b/bigip/resource_bigip_ltm_datagroup_test.go
@@ -30,6 +30,12 @@ var TestDatagroupStringResource = `
                 }
         }`
 
+var TestDatagroupStringResourceEmpty = `
+        resource "bigip_ltm_datagroup" "test-datagroup-string" {
+                name = "` + TestDatagroupName + `"
+                type = "string"
+        }`
+
 var TestExternalDatagroupResource = `
 resource "bigip_ltm_datagroup" "test-datagroup-string" {
 		name = "` + TestDatagroupName + `"
@@ -136,6 +142,32 @@ func TestAccBigipLtmDataGroup_Create_TypeInteger(t *testing.T) {
 	})
 }
 
+func TestAccBigipLtmDataGroup_Update_ClearRecords(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckDataGroupDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: TestDatagroupStringResource,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckDataGroupExists(TestDatagroupName),
+					testCheckDataGroupRecordCount(TestDatagroupName, 2),
+				),
+			},
+			{
+				Config: TestDatagroupStringResourceEmpty,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckDataGroupExists(TestDatagroupName),
+					testCheckDataGroupRecordCount(TestDatagroupName, 0),
+				),
+			},
+		},
+	})
+}
+
 func TestAccBigipLtmDataGroup_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -208,6 +240,24 @@ func testCheckDataGroupExists(name string) resource.TestCheckFunc {
 		datagroupName := fmt.Sprintf("/%s/%s", datagroup.Partition, datagroup.Name)
 		if datagroupName != name {
 			return fmt.Errorf("Data Group name does not match. Expecting %s got %s ", name, datagroupName)
+		}
+		return nil
+	}
+}
+
+func testCheckDataGroupRecordCount(name string, expected int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*bigip.BigIP)
+
+		datagroup, err := client.GetInternalDataGroup(name)
+		if err != nil {
+			return fmt.Errorf("Error while fetching Data Group: %v ", err)
+		}
+		if datagroup == nil {
+			return fmt.Errorf("Data Group %s not found", name)
+		}
+		if got := len(datagroup.Records); got != expected {
+			return fmt.Errorf("Data Group %s record count mismatch. Expected %d, got %d", name, expected, got)
 		}
 		return nil
 	}

--- a/vendor/github.com/f5devcentral/go-bigip/ltm.go
+++ b/vendor/github.com/f5devcentral/go-bigip/ltm.go
@@ -222,7 +222,7 @@ type dataGroupDTO struct {
 	FullPath   string            `json:"fullPath,omitempty"`
 	Generation int               `json:"generation,omitempty"`
 	Type       string            `json:"type,omitempty"`
-	Records    []DataGroupRecord `json:"records,omitempty"`
+	Records    []DataGroupRecord `json:"records"`
 }
 
 func (p *DataGroup) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
## Summary
- Drop `omitempty` from `Records` on the vendored `dataGroupDTO` so a PUT with an empty record set actually sends `"records": []` to BigIP. With `omitempty`, both `nil` and `[]` were stripped and BigIP kept the existing records.
- `resource_bigip_ltm_datagroup.go` now initializes `records` as `[]bigip.DataGroupRecord{}` (instead of leaving it nil) so an empty record set serializes as `[]` rather than `null`. Simplifies the create/update paths slightly.
- Adds `TestAccBigipLtmDataGroup_Update_ClearRecords`, a two-step acceptance test that creates a data group with two records and then applies an empty config — asserting the live BigIP record count goes from 2 → 0 while the data group itself survives.

Fixes #1164

## Test plan
- [ ] `go build ./...` (passes locally)
- [ ] `go vet ./...` (passes locally)
- [ ] `TF_ACC=1 go test ./bigip/ -run TestAccBigipLtmDataGroup_Update_ClearRecords -v` against a live BigIP

## Note on the vendor change
The actual on-the-wire fix lives in `vendor/github.com/f5devcentral/go-bigip/ltm.go`. The matching upstream PR is [f5devcentral/go-bigip#132](https://github.com/f5devcentral/go-bigip/pull/132) — landing that means the next `go mod vendor` won't revert the fix here.
