### PR TITLE
fix: gtm topology records

### DIFF
--- a/bigip/resource_bigip_gtm_topology_record.go
+++ b/bigip/resource_bigip_gtm_topology_record.go
@@ -4,11 +4,44 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 
 	bigip "github.com/f5devcentral/go-bigip"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
+
+// topologyEndpointSchema returns the schema shared by the ldns and server blocks.
+func topologyEndpointSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"match_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"region", "datacenter", "pool", "subnet",
+					"country", "state", "continent", "isp",
+				}, false),
+				Description: "The match type. Valid values: region, datacenter, pool, subnet, country, state, continent, isp",
+			},
+			"match_value": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The match value (e.g. /Common/east-coast, 10.0.0.0/8, US, US/California, NA, /Common/my-pool)",
+			},
+			"match_negate": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				ForceNew:    true,
+				Description: "If true, the match is negated (uses 'not' prefix)",
+			},
+		},
+	}
+}
 
 func resourceBigipGtmTopologyRecord() *schema.Resource {
 	return &schema.Resource{
@@ -17,41 +50,128 @@ func resourceBigipGtmTopologyRecord() *schema.Resource {
 		UpdateContext: resourceBigipGtmTopologyRecordUpdate,
 		DeleteContext: resourceBigipGtmTopologyRecordDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceBigipGtmTopologyRecordImport,
 		},
 
 		Schema: map[string]*schema.Schema{
-			"description": {
-				Type:        schema.TypeString,
+			"ldns": {
+				Type:        schema.TypeList,
 				Required:    true,
 				ForceNew:    true,
-				Description: "The topology record description that defines the source and destination match. Format: 'ldns: <source> server: <destination>' (e.g., 'ldns: region /Common/my-region server: datacenter /Common/my-dc')",
+				MaxItems:    1,
+				Description: "The LDNS (source) match criteria",
+				Elem:        topologyEndpointSchema(),
+			},
+			"server": {
+				Type:        schema.TypeList,
+				Required:    true,
+				ForceNew:    true,
+				MaxItems:    1,
+				Description: "The server (destination) match criteria",
+				Elem:        topologyEndpointSchema(),
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "User defined description",
 			},
 			"order": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     0,
-				Description: "The order in which the topology record is evaluated",
+				Description: "The order in which the topology record is evaluated. Lower values are evaluated first.",
 			},
 			"score": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     1,
-				Description: "The weight or preference given to this topology record",
+				Description: "The weight or preference given to this topology record. Higher scores indicate stronger preference.",
 			},
 		},
 	}
 }
 
+// buildTopologyName constructs the BIG-IP topology name string from ldns and server blocks.
+// The BIG-IP REST API requires the topology definition in the "name" field with the format:
+//
+//	"ldns: <type> <value> server: <type> <value>"
+//
+// For example: "ldns: region /Common/east-coast server: datacenter /Common/dc1"
+// Negation is expressed as: "ldns: not region /Common/east-coast server: datacenter /Common/dc1"
+func buildTopologyName(d *schema.ResourceData) string {
+	ldnsList := d.Get("ldns").([]interface{})
+	serverList := d.Get("server").([]interface{})
+
+	ldns := ldnsList[0].(map[string]interface{})
+	server := serverList[0].(map[string]interface{})
+
+	ldnsStr := buildEndpointString(ldns)
+	serverStr := buildEndpointString(server)
+
+	return fmt.Sprintf("ldns: %s server: %s", ldnsStr, serverStr)
+}
+
+func buildEndpointString(endpoint map[string]interface{}) string {
+	matchType := endpoint["match_type"].(string)
+	matchValue := endpoint["match_value"].(string)
+	negate := endpoint["match_negate"].(bool)
+
+	if negate {
+		return fmt.Sprintf("not %s %s", matchType, matchValue)
+	}
+	return fmt.Sprintf("%s %s", matchType, matchValue)
+}
+
+// parseTopologyName parses a BIG-IP topology name string back into ldns and server components.
+// Input format: "ldns: [not] <type> <value> server: [not] <type> <value>"
+func parseTopologyName(name string) (ldnsType, ldnsValue string, ldnsNegate bool, serverType, serverValue string, serverNegate bool, err error) {
+	// Split on " server: " to separate ldns and server parts
+	parts := strings.SplitN(name, " server: ", 2)
+	if len(parts) != 2 {
+		err = fmt.Errorf("invalid topology name format: %s", name)
+		return
+	}
+
+	ldnsPart := strings.TrimPrefix(parts[0], "ldns: ")
+	serverPart := parts[1]
+
+	ldnsType, ldnsValue, ldnsNegate, err = parseEndpointString(ldnsPart)
+	if err != nil {
+		return
+	}
+
+	serverType, serverValue, serverNegate, err = parseEndpointString(serverPart)
+	return
+}
+
+func parseEndpointString(s string) (matchType, matchValue string, negate bool, err error) {
+	s = strings.TrimSpace(s)
+
+	if strings.HasPrefix(s, "not ") {
+		negate = true
+		s = strings.TrimPrefix(s, "not ")
+	}
+
+	// The first token is the type, everything after is the value
+	var found bool
+	matchType, matchValue, found = strings.Cut(s, " ")
+	if !found {
+		err = fmt.Errorf("invalid endpoint format: %s", s)
+		return
+	}
+	return
+}
+
 func resourceBigipGtmTopologyRecordCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*bigip.BigIP)
 
-	description := d.Get("description").(string)
+	topologyName := buildTopologyName(d)
 
-	log.Printf("[INFO] Creating GTM Topology Record: %s", description)
+	log.Printf("[INFO] Creating GTM Topology Record: %s", topologyName)
 
 	config := &bigip.GTMTopologyRecord{
-		Description: description,
+		Name:        topologyName,
+		Description: d.Get("description").(string),
 		Order:       d.Get("order").(int),
 		Score:       d.Get("score").(int),
 	}
@@ -61,7 +181,7 @@ func resourceBigipGtmTopologyRecordCreate(ctx context.Context, d *schema.Resourc
 		return diag.FromErr(fmt.Errorf("error creating GTM Topology Record: %v", err))
 	}
 
-	d.SetId(description)
+	d.SetId(topologyName)
 
 	return resourceBigipGtmTopologyRecordRead(ctx, d, meta)
 }
@@ -69,11 +189,11 @@ func resourceBigipGtmTopologyRecordCreate(ctx context.Context, d *schema.Resourc
 func resourceBigipGtmTopologyRecordRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*bigip.BigIP)
 
-	description := d.Id()
+	topologyName := d.Id()
 
-	log.Printf("[INFO] Reading GTM Topology Record: %s", description)
+	log.Printf("[INFO] Reading GTM Topology Record: %s", topologyName)
 
-	record, err := client.GetGTMTopologyRecord(description)
+	record, err := client.GetGTMTopologyRecord(topologyName)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error retrieving GTM Topology Record: %v", err))
 	}
@@ -83,6 +203,34 @@ func resourceBigipGtmTopologyRecordRead(ctx context.Context, d *schema.ResourceD
 		return nil
 	}
 
+	// Parse the API name back into structured fields
+	apiName := record.Name
+	if apiName == "" {
+		apiName = topologyName
+	}
+
+	ldnsType, ldnsValue, ldnsNegate, serverType, serverValue, serverNegate, parseErr := parseTopologyName(apiName)
+	if parseErr != nil {
+		return diag.FromErr(fmt.Errorf("error parsing GTM Topology Record name '%s': %v", apiName, parseErr))
+	}
+
+	ldns := []interface{}{
+		map[string]interface{}{
+			"match_type":   ldnsType,
+			"match_value":  ldnsValue,
+			"match_negate": ldnsNegate,
+		},
+	}
+	server := []interface{}{
+		map[string]interface{}{
+			"match_type":   serverType,
+			"match_value":  serverValue,
+			"match_negate": serverNegate,
+		},
+	}
+
+	d.Set("ldns", ldns)
+	d.Set("server", server)
 	d.Set("description", record.Description)
 	d.Set("order", record.Order)
 	d.Set("score", record.Score)
@@ -93,17 +241,18 @@ func resourceBigipGtmTopologyRecordRead(ctx context.Context, d *schema.ResourceD
 func resourceBigipGtmTopologyRecordUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*bigip.BigIP)
 
-	description := d.Id()
+	topologyName := d.Id()
 
-	log.Printf("[INFO] Updating GTM Topology Record: %s", description)
+	log.Printf("[INFO] Updating GTM Topology Record: %s", topologyName)
 
 	config := &bigip.GTMTopologyRecord{
-		Description: description,
+		Name:        topologyName,
+		Description: d.Get("description").(string),
 		Order:       d.Get("order").(int),
 		Score:       d.Get("score").(int),
 	}
 
-	err := client.ModifyGTMTopologyRecord(description, config)
+	err := client.ModifyGTMTopologyRecord(topologyName, config)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating GTM Topology Record: %v", err))
 	}
@@ -114,15 +263,28 @@ func resourceBigipGtmTopologyRecordUpdate(ctx context.Context, d *schema.Resourc
 func resourceBigipGtmTopologyRecordDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*bigip.BigIP)
 
-	description := d.Id()
+	topologyName := d.Id()
 
-	log.Printf("[INFO] Deleting GTM Topology Record: %s", description)
+	log.Printf("[INFO] Deleting GTM Topology Record: %s", topologyName)
 
-	err := client.DeleteGTMTopologyRecord(description)
+	err := client.DeleteGTMTopologyRecord(topologyName)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting GTM Topology Record: %v", err))
 	}
 
 	d.SetId("")
 	return nil
+}
+
+// resourceBigipGtmTopologyRecordImport handles terraform import by parsing the
+// topology name string into structured state.
+func resourceBigipGtmTopologyRecordImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	topologyName := d.Id()
+
+	_, _, _, _, _, _, err := parseTopologyName(topologyName)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing import ID '%s': %v. Expected format: 'ldns: <type> <value> server: <type> <value>'", topologyName, err)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/bigip/resource_bigip_gtm_topology_test.go
+++ b/bigip/resource_bigip_gtm_topology_test.go
@@ -47,16 +47,72 @@ func TestResourceBigipGtmTopologyRecordSchema(t *testing.T) {
 		t.Error("Expected DeleteContext to be defined")
 	}
 
-	// description is required and ForceNew
+	// ldns is required, TypeList, MaxItems 1
+	ldnsField, ok := resource.Schema["ldns"]
+	if !ok {
+		t.Fatal("Expected 'ldns' field to exist")
+	}
+	if !ldnsField.Required {
+		t.Error("Expected 'ldns' to be required")
+	}
+	if ldnsField.Type != schema.TypeList {
+		t.Errorf("Expected 'ldns' to be TypeList, got %v", ldnsField.Type)
+	}
+	if ldnsField.MaxItems != 1 {
+		t.Errorf("Expected 'ldns' MaxItems to be 1, got %d", ldnsField.MaxItems)
+	}
+	ldnsElem, ok := ldnsField.Elem.(*schema.Resource)
+	if !ok {
+		t.Fatal("Expected 'ldns' Elem to be a *schema.Resource")
+	}
+	if _, ok := ldnsElem.Schema["match_type"]; !ok {
+		t.Error("Expected 'ldns.match_type' field to exist")
+	}
+	if _, ok := ldnsElem.Schema["match_value"]; !ok {
+		t.Error("Expected 'ldns.match_value' field to exist")
+	}
+	if _, ok := ldnsElem.Schema["match_negate"]; !ok {
+		t.Error("Expected 'ldns.match_negate' field to exist")
+	}
+
+	// server is required, TypeList, MaxItems 1
+	serverField, ok := resource.Schema["server"]
+	if !ok {
+		t.Fatal("Expected 'server' field to exist")
+	}
+	if !serverField.Required {
+		t.Error("Expected 'server' to be required")
+	}
+	if serverField.Type != schema.TypeList {
+		t.Errorf("Expected 'server' to be TypeList, got %v", serverField.Type)
+	}
+	if serverField.MaxItems != 1 {
+		t.Errorf("Expected 'server' MaxItems to be 1, got %d", serverField.MaxItems)
+	}
+	serverElem, ok := serverField.Elem.(*schema.Resource)
+	if !ok {
+		t.Fatal("Expected 'server' Elem to be a *schema.Resource")
+	}
+	if _, ok := serverElem.Schema["match_type"]; !ok {
+		t.Error("Expected 'server.match_type' field to exist")
+	}
+	if _, ok := serverElem.Schema["match_value"]; !ok {
+		t.Error("Expected 'server.match_value' field to exist")
+	}
+	if _, ok := serverElem.Schema["match_negate"]; !ok {
+		t.Error("Expected 'server.match_negate' field to exist")
+	}
+
+	// description is optional
 	descField, ok := resource.Schema["description"]
 	if !ok {
 		t.Fatal("Expected 'description' field to exist")
 	}
-	if !descField.Required {
-		t.Error("Expected 'description' to be required")
+	if descField.Required {
+		t.Error("Expected 'description' to be optional, not required")
 	}
-	if !descField.ForceNew {
-		t.Error("Expected 'description' to be ForceNew")
+	if descField.Type != schema.TypeString {
+		t.Errorf("Expected 'description' to be TypeString, got %v", descField.Type)
 	}
 
 	// order is optional with default 0
@@ -147,9 +203,9 @@ func TestResourceBigipGtmTopologyRegionSchema(t *testing.T) {
 
 func TestGTMTopologyRecordMarshalJSON(t *testing.T) {
 	record := bigip.GTMTopologyRecord{
-		Description: "ldns: region /Common/east-coast server: datacenter /Common/dc1",
-		Order:       1,
-		Score:       100,
+		Name:  "ldns: region /Common/east-coast server: datacenter /Common/dc1",
+		Order: 1,
+		Score: 100,
 	}
 
 	data, err := json.Marshal(record)
@@ -162,8 +218,8 @@ func TestGTMTopologyRecordMarshalJSON(t *testing.T) {
 		t.Fatalf("Failed to unmarshal JSON: %v", err)
 	}
 
-	if result["description"] != "ldns: region /Common/east-coast server: datacenter /Common/dc1" {
-		t.Errorf("Expected description to match, got '%v'", result["description"])
+	if result["name"] != "ldns: region /Common/east-coast server: datacenter /Common/dc1" {
+		t.Errorf("Expected name to match, got '%v'", result["name"])
 	}
 	if int(result["order"].(float64)) != 1 {
 		t.Errorf("Expected order 1, got %v", result["order"])
@@ -176,7 +232,6 @@ func TestGTMTopologyRecordMarshalJSON(t *testing.T) {
 func TestGTMTopologyRecordUnmarshalJSON(t *testing.T) {
 	jsonData := `{
 		"name": "ldns: region /Common/east-coast server: datacenter /Common/dc1",
-		"description": "ldns: region /Common/east-coast server: datacenter /Common/dc1",
 		"order": 2,
 		"score": 50
 	}`
@@ -186,14 +241,155 @@ func TestGTMTopologyRecordUnmarshalJSON(t *testing.T) {
 		t.Fatalf("Failed to unmarshal GTMTopologyRecord: %v", err)
 	}
 
-	if record.Description != "ldns: region /Common/east-coast server: datacenter /Common/dc1" {
-		t.Errorf("Expected description match, got '%s'", record.Description)
+	if record.Name != "ldns: region /Common/east-coast server: datacenter /Common/dc1" {
+		t.Errorf("Expected name match, got '%s'", record.Name)
 	}
 	if record.Order != 2 {
 		t.Errorf("Expected order 2, got %d", record.Order)
 	}
 	if record.Score != 50 {
 		t.Errorf("Expected score 50, got %d", record.Score)
+	}
+}
+
+func TestParseTopologyName(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		ldnsType     string
+		ldnsValue    string
+		ldnsNegate   bool
+		serverType   string
+		serverValue  string
+		serverNegate bool
+		expectErr    bool
+	}{
+		{
+			name:        "region to datacenter",
+			input:       "ldns: region /Common/east-coast server: datacenter /Common/dc1",
+			ldnsType:    "region",
+			ldnsValue:   "/Common/east-coast",
+			serverType:  "datacenter",
+			serverValue: "/Common/dc1",
+		},
+		{
+			name:        "subnet to pool",
+			input:       "ldns: subnet 10.0.0.0/8 server: pool /Common/internal-pool",
+			ldnsType:    "subnet",
+			ldnsValue:   "10.0.0.0/8",
+			serverType:  "pool",
+			serverValue: "/Common/internal-pool",
+		},
+		{
+			name:        "country to datacenter",
+			input:       "ldns: country US server: datacenter /Common/us-dc",
+			ldnsType:    "country",
+			ldnsValue:   "US",
+			serverType:  "datacenter",
+			serverValue: "/Common/us-dc",
+		},
+		{
+			name:        "state to datacenter",
+			input:       "ldns: state US/California server: datacenter /Common/west-dc",
+			ldnsType:    "state",
+			ldnsValue:   "US/California",
+			serverType:  "datacenter",
+			serverValue: "/Common/west-dc",
+		},
+		{
+			name:        "negated ldns",
+			input:       "ldns: not region /Common/east-coast server: datacenter /Common/dc1",
+			ldnsType:    "region",
+			ldnsValue:   "/Common/east-coast",
+			ldnsNegate:  true,
+			serverType:  "datacenter",
+			serverValue: "/Common/dc1",
+		},
+		{
+			name:         "negated server",
+			input:        "ldns: region /Common/east-coast server: not datacenter /Common/dc1",
+			ldnsType:     "region",
+			ldnsValue:    "/Common/east-coast",
+			serverType:   "datacenter",
+			serverValue:  "/Common/dc1",
+			serverNegate: true,
+		},
+		{
+			name:      "invalid format",
+			input:     "some invalid string",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lt, lv, ln, st, sv, sn, err := parseTopologyName(tt.input)
+			if tt.expectErr {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if lt != tt.ldnsType {
+				t.Errorf("ldns type: expected '%s', got '%s'", tt.ldnsType, lt)
+			}
+			if lv != tt.ldnsValue {
+				t.Errorf("ldns value: expected '%s', got '%s'", tt.ldnsValue, lv)
+			}
+			if ln != tt.ldnsNegate {
+				t.Errorf("ldns negate: expected %v, got %v", tt.ldnsNegate, ln)
+			}
+			if st != tt.serverType {
+				t.Errorf("server type: expected '%s', got '%s'", tt.serverType, st)
+			}
+			if sv != tt.serverValue {
+				t.Errorf("server value: expected '%s', got '%s'", tt.serverValue, sv)
+			}
+			if sn != tt.serverNegate {
+				t.Errorf("server negate: expected %v, got %v", tt.serverNegate, sn)
+			}
+		})
+	}
+}
+
+func TestBuildEndpointString(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint map[string]interface{}
+		expected string
+	}{
+		{
+			name:     "simple region",
+			endpoint: map[string]interface{}{"match_type": "region", "match_value": "/Common/east-coast", "match_negate": false},
+			expected: "region /Common/east-coast",
+		},
+		{
+			name:     "negated region",
+			endpoint: map[string]interface{}{"match_type": "region", "match_value": "/Common/east-coast", "match_negate": true},
+			expected: "not region /Common/east-coast",
+		},
+		{
+			name:     "subnet",
+			endpoint: map[string]interface{}{"match_type": "subnet", "match_value": "10.0.0.0/8", "match_negate": false},
+			expected: "subnet 10.0.0.0/8",
+		},
+		{
+			name:     "country",
+			endpoint: map[string]interface{}{"match_type": "country", "match_value": "US", "match_negate": false},
+			expected: "country US",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildEndpointString(tt.endpoint)
+			if result != tt.expected {
+				t.Errorf("Expected '%s', got '%s'", tt.expected, result)
+			}
+		})
 	}
 }
 

--- a/docs/resources/bigip_gtm_topology_record.md
+++ b/docs/resources/bigip_gtm_topology_record.md
@@ -10,9 +10,18 @@ A GTM topology record defines a routing rule for topology-based load balancing. 
 
 ```hcl
 resource "bigip_gtm_topology_record" "east_to_dc1" {
-  description = "ldns: region /Common/east-coast server: datacenter /Common/dc1"
-  order       = 1
-  score       = 100
+  ldns {
+    match_type  = "region"
+    match_value = "/Common/east-coast"
+  }
+
+  server {
+    match_type  = "datacenter"
+    match_value = "/Common/dc1"
+  }
+
+  order = 1
+  score = 100
 }
 ```
 
@@ -20,9 +29,18 @@ resource "bigip_gtm_topology_record" "east_to_dc1" {
 
 ```hcl
 resource "bigip_gtm_topology_record" "internal_to_pool" {
-  description = "ldns: subnet 10.0.0.0/8 server: pool /Common/internal-pool"
-  order       = 2
-  score       = 50
+  ldns {
+    match_type  = "subnet"
+    match_value = "10.0.0.0/8"
+  }
+
+  server {
+    match_type  = "pool"
+    match_value = "/Common/internal-pool"
+  }
+
+  order = 2
+  score = 50
 }
 ```
 
@@ -30,9 +48,37 @@ resource "bigip_gtm_topology_record" "internal_to_pool" {
 
 ```hcl
 resource "bigip_gtm_topology_record" "us_to_us_dc" {
-  description = "ldns: country US server: datacenter /Common/us-datacenter"
-  order       = 3
-  score       = 75
+  ldns {
+    match_type  = "country"
+    match_value = "US"
+  }
+
+  server {
+    match_type  = "datacenter"
+    match_value = "/Common/us-datacenter"
+  }
+
+  order = 3
+  score = 75
+}
+```
+
+### Using Negation
+
+```hcl
+resource "bigip_gtm_topology_record" "not_east_to_dc2" {
+  ldns {
+    match_type   = "region"
+    match_value  = "/Common/east-coast"
+    match_negate = true
+  }
+
+  server {
+    match_type  = "datacenter"
+    match_value = "/Common/dc2"
+  }
+
+  score = 50
 }
 ```
 
@@ -53,9 +99,18 @@ resource "bigip_gtm_topology_region" "east_coast" {
 }
 
 resource "bigip_gtm_topology_record" "east_to_dc1" {
-  description = "ldns: region /Common/east-coast server: datacenter /Common/dc1"
-  order       = 1
-  score       = 100
+  ldns {
+    match_type  = "region"
+    match_value = "/Common/east-coast"
+  }
+
+  server {
+    match_type  = "datacenter"
+    match_value = "/Common/dc1"
+  }
+
+  order = 1
+  score = 100
 
   depends_on = [bigip_gtm_topology_region.east_coast]
 }
@@ -63,15 +118,22 @@ resource "bigip_gtm_topology_record" "east_to_dc1" {
 
 ## Argument Reference
 
-* `description` - (Required) The topology record description that defines the source and destination match. This follows the BIG-IP format: `ldns: <source> server: <destination>`. Cannot be changed after creation. Valid source/destination types include:
-  - `region <path>` - e.g., `region /Common/east-coast`
-  - `datacenter <path>` - e.g., `datacenter /Common/dc1`
-  - `pool <path>` - e.g., `pool /Common/my-pool`
-  - `subnet <cidr>` - e.g., `subnet 10.0.0.0/8`
-  - `country <code>` - e.g., `country US`
-  - `state <country>/<state>` - e.g., `state US/California`
-  - `continent <code>` - e.g., `continent NA`
-  - `isp <name>` - e.g., `isp Comcast`
+* `ldns` - (Required) The LDNS (source) match criteria block. Cannot be changed after creation. Contains the following:
+  - `match_type` - (Required) The type of match. Valid values:
+    - `region` - e.g., match_value = `/Common/east-coast`
+    - `datacenter` - e.g., match_value = `/Common/dc1`
+    - `pool` - e.g., match_value = `/Common/my-pool`
+    - `subnet` - e.g., match_value = `10.0.0.0/8`
+    - `country` - e.g., match_value = `US`
+    - `state` - e.g., match_value = `US/California`
+    - `continent` - e.g., match_value = `NA`
+    - `isp` - e.g., match_value = `Comcast`
+  - `match_value` - (Required) The value to match against.
+  - `match_negate` - (Optional) If `true`, the match is negated. Default is `false`.
+
+* `server` - (Required) The server (destination) match criteria block. Cannot be changed after creation. Same nested arguments as `ldns`.
+
+* `description` - (Optional) User defined description.
 
 * `order` - (Optional) The order in which the topology record is evaluated. Lower values are evaluated first. Default is `0`.
 
@@ -81,11 +143,11 @@ resource "bigip_gtm_topology_record" "east_to_dc1" {
 
 In addition to the arguments listed above, the following computed attributes are exported:
 
-* `id` - The description string of the topology record.
+* `id` - The topology record identifier in the format `ldns: <type> <value> server: <type> <value>`.
 
 ## Import
 
-GTM topology records can be imported using the description string, e.g.
+GTM topology records can be imported using the topology definition string, e.g.
 
 ```
 terraform import bigip_gtm_topology_record.example "ldns: region /Common/east-coast server: datacenter /Common/dc1"
@@ -94,6 +156,6 @@ terraform import bigip_gtm_topology_record.example "ldns: region /Common/east-co
 ## Notes
 
 * Topology records are evaluated in order. Use the `order` field to control evaluation priority.
-* The `description` field cannot be changed after creation. To modify the source/destination match, destroy and recreate the record.
+* The `ldns` and `server` blocks cannot be changed after creation. To modify the source/destination match, destroy and recreate the record.
 * Regions referenced in topology records must exist before the record is created. Use `depends_on` to enforce ordering.
 * Topology records are only effective when a WideIP's `pool_lb_mode` is set to `topology`.


### PR DESCRIPTION
### Problem

The `bigip_gtm_topology_record` resource was fundamentally broken. It required users to manually construct a raw API format string in a `description` field (e.g., `"ldns: region /Common/ipc server: pool /Common/mypool"`), which was:

1. **Non-functional** — The resource sent the topology definition as `description` to the BIG-IP REST API, but the API requires it in the `name` field. This caused every create operation to fail with: `"Operation is not supported on component /gtm/topology"`
2. **Poorly designed** — No input validation, no structured fields, error-prone string format that users had to know and construct manually
3. **Inconsistent** — Every other Terraform resource uses structured fields, not opaque format strings

### Solution

Complete redesign of the resource to use proper structured blocks that match the BIG-IP GTM topology API (`/mgmt/tm/gtm/topology`).

**Before (broken):**

```hcl
resource "bigip_gtm_topology_record" "example" {
  description = "ldns: region /Common/ipc server: pool /Common/mypool"
  score       = 100
}
```

**After (working):**

```hcl
resource "bigip_gtm_topology_record" "example" {
  ldns {
    match_type  = "region"
    match_value = "/Common/ipc"
  }

  server {
    match_type  = "pool"
    match_value = "/Common/mypool"
  }

  score = 100
}
```

### Changes

#### `bigip/resource_bigip_gtm_topology_record.go`

- Replaced single `description` string field with required `ldns {}` and `server {}` blocks
- Each block contains `match_type` (validated against 8 allowed values), `match_value`, and optional `match_negate`
- `description` retained as an optional field (maps to the API's user-defined description)
- `order` (default 0) and `score` (default 1) unchanged
- Added `buildTopologyName()` to construct the API `name` field from structured blocks
- Added `parseTopologyName()` to parse API responses back into structured state
- Added custom import handler with format validation
- Topology definition sent correctly as `name` (natural key) per the [F5 API reference](https://clouddocs.f5.com/api/icontrol-rest/APIRef_tm_gtm_topology.html)

#### `bigip/resource_bigip_gtm_topology_test.go`

- Updated schema tests to verify new `ldns`, `server`, `description`, `order`, `score` fields
- Updated JSON marshal/unmarshal tests to use `Name` field
- Added `TestParseTopologyName` — 7 table-driven subtests covering region, subnet, country, state, negation, and invalid input
- Added `TestBuildEndpointString` — 4 subtests for endpoint string construction

#### `docs/resources/bigip_gtm_topology_record.md`

- Rewritten with 5 examples: region→datacenter, subnet→pool, country→datacenter, negation, and topology region integration
- Argument reference documents all fields and valid `match_type` values
- Import and notes sections updated

### API Field Mapping

| BIG-IP API Field | Terraform Schema | Notes |
|------------------|------------------|-------|
| `name` (natural key) | Built from `ldns` + `server` blocks | Users never set this directly |
| `description` | `description` (optional) | Freetext user note |
| `order` | `order` (optional, default 0) | Evaluation order |
| `score` | `score` (optional, default 1) | Topology weight |

### Testing

All 15 unit tests pass:

```
=== RUN   TestResourceBigipGtmTopologyRecordExists       --- PASS
=== RUN   TestResourceBigipGtmTopologyRecordSchema        --- PASS
=== RUN   TestGTMTopologyRecordMarshalJSON                --- PASS
=== RUN   TestGTMTopologyRecordUnmarshalJSON              --- PASS
=== RUN   TestParseTopologyName (7 subtests)              --- PASS
=== RUN   TestBuildEndpointString (4 subtests)            --- PASS
```