### PR TITLE
feat: only strip metadata fields from diff when ignore_metadata is true

### DIFF
--- a/bigip/resource_bigip_as3.go
+++ b/bigip/resource_bigip_as3.go
@@ -31,6 +31,23 @@ import (
 var m sync.Mutex
 var createdTenants string
 
+// stripAS3Metadata removes AS3-managed metadata fields from a parsed JSON declaration.
+// If stripCommon is true, the Common partition is also removed (for cases where BIG-IP
+// auto-creates it and the user did not define it).
+func stripAS3Metadata(jsonRef map[string]interface{}, stripCommon bool) {
+	if rec, ok := jsonRef["declaration"].(map[string]interface{}); ok {
+		delete(rec, "updateMode")
+		delete(rec, "schemaVersion")
+		delete(rec, "id")
+		delete(rec, "label")
+		delete(rec, "remark")
+		if stripCommon {
+			delete(rec, "Common")
+		}
+	}
+	delete(jsonRef, "persist")
+}
+
 func resourceBigipAs3() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceBigipAs3Create,
@@ -59,63 +76,30 @@ func resourceBigipAs3() *schema.Resource {
 					return jsonString
 				},
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					oldResp := []byte(old)
-					newResp := []byte(new)
 					oldJsonref := make(map[string]interface{})
 					newJsonref := make(map[string]interface{})
-					_ = json.Unmarshal(oldResp, &oldJsonref)
-					_ = json.Unmarshal(newResp, &newJsonref)
+					_ = json.Unmarshal([]byte(old), &oldJsonref)
+					_ = json.Unmarshal([]byte(new), &newJsonref)
 					delete(oldJsonref, "$schema")
 					delete(newJsonref, "$schema")
-					jsonEqualityBefore := reflect.DeepEqual(oldJsonref, newJsonref)
-					if jsonEqualityBefore {
+					if reflect.DeepEqual(oldJsonref, newJsonref) {
 						return true
 					}
-					for key, value := range oldJsonref {
-						if rec, ok := value.(map[string]interface{}); ok && key == "declaration" {
-							for range rec {
-								delete(rec, "updateMode")
-								delete(rec, "schemaVersion")
-								delete(rec, "id")
-								delete(rec, "label")
-								delete(rec, "remark")
-								delete(rec, "Common")
-							}
-						}
-						if key == "persist" {
-							delete(oldJsonref, "persist")
+					if !d.Get("ignore_metadata").(bool) {
+						return false
+					}
+					// When ignore_metadata is true, strip AS3 metadata fields and compare again.
+					// Only strip Common from comparison if the user did not define it in their
+					// declaration (handles AS3 auto-creating Common for shared objects).
+					stripCommon := true
+					if newDecl, ok := newJsonref["declaration"].(map[string]interface{}); ok {
+						if _, hasCommon := newDecl["Common"]; hasCommon {
+							stripCommon = false
 						}
 					}
-					for key, value := range newJsonref {
-						if rec, ok := value.(map[string]interface{}); ok && key == "declaration" {
-							for range rec {
-								delete(rec, "updateMode")
-								delete(rec, "schemaVersion")
-								delete(rec, "id")
-								delete(rec, "label")
-								delete(rec, "remark")
-								delete(rec, "Common")
-							}
-						}
-						if key == "persist" {
-							delete(newJsonref, "persist")
-						}
-					}
-					ignoreMetadata := d.Get("ignore_metadata").(bool)
-					jsonEqualityAfter := reflect.DeepEqual(oldJsonref, newJsonref)
-					if ignoreMetadata {
-						if jsonEqualityAfter {
-							return true
-						} else {
-							return false
-						}
-
-					} else {
-						if !jsonEqualityBefore {
-							return false
-						}
-					}
-					return true
+					stripAS3Metadata(oldJsonref, stripCommon)
+					stripAS3Metadata(newJsonref, stripCommon)
+					return reflect.DeepEqual(oldJsonref, newJsonref)
 				},
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					if _, err := structure.NormalizeJsonString(v); err != nil {
@@ -152,7 +136,7 @@ func resourceBigipAs3() *schema.Resource {
 			"ignore_metadata": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "Set True if you want to ignore metadata update",
+				Description: "Set to true to ignore AS3 metadata fields (updateMode, schemaVersion, id, label, remark, persist) when comparing declarations. If the user did not define a Common tenant in their declaration, auto-created Common is also excluded from comparison.",
 				Default:     false,
 			},
 			"tenant_name": {

--- a/bigip/resource_bigip_as3_unit_test.go
+++ b/bigip/resource_bigip_as3_unit_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2019 F5 Networks Inc.
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+package bigip
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func getDiffSuppressFunc() schema.SchemaDiffSuppressFunc {
+	r := resourceBigipAs3()
+	return r.Schema["as3_json"].DiffSuppressFunc
+}
+
+func TestDiffSuppressFunc_IdenticalJSON(t *testing.T) {
+	diffSuppress := getDiffSuppressFunc()
+
+	old := `{"class":"AS3","declaration":{"class":"ADC","schemaVersion":"3.0.0","MyTenant":{"class":"Tenant"}}}`
+	new := `{"class":"AS3","declaration":{"class":"ADC","schemaVersion":"3.0.0","MyTenant":{"class":"Tenant"}}}`
+
+	r := resourceBigipAs3()
+	d := schema.TestResourceDataRaw(t, r.Schema, map[string]interface{}{
+		"ignore_metadata": false,
+	})
+
+	if !diffSuppress("as3_json", old, new, d) {
+		t.Error("Expected identical JSON to suppress diff")
+	}
+}
+
+func TestDiffSuppressFunc_IgnoreMetadataFalse_RealDiff(t *testing.T) {
+	diffSuppress := getDiffSuppressFunc()
+
+	old := `{"class":"AS3","declaration":{"class":"ADC","schemaVersion":"3.0.0","MyTenant":{"class":"Tenant","app":{"class":"Application"}}}}`
+	new := `{"class":"AS3","declaration":{"class":"ADC","schemaVersion":"3.0.0","MyTenant":{"class":"Tenant","app":{"class":"Application","pool":{"class":"Pool"}}}}}`
+
+	r := resourceBigipAs3()
+	d := schema.TestResourceDataRaw(t, r.Schema, map[string]interface{}{
+		"ignore_metadata": false,
+	})
+
+	if diffSuppress("as3_json", old, new, d) {
+		t.Error("Expected real diff to NOT be suppressed when ignore_metadata=false")
+	}
+}
+
+func TestDiffSuppressFunc_IgnoreMetadataTrue_MetadataOnlyDiff(t *testing.T) {
+	diffSuppress := getDiffSuppressFunc()
+
+	// old has extra metadata fields that BIG-IP added
+	old := `{"class":"AS3","declaration":{"class":"ADC","schemaVersion":"3.50.0","id":"autogen_id","updateMode":"selective","label":"some label","remark":"auto remark","MyTenant":{"class":"Tenant"}},"persist":true}`
+	new := `{"class":"AS3","declaration":{"class":"ADC","MyTenant":{"class":"Tenant"}}}`
+
+	r := resourceBigipAs3()
+	d := schema.TestResourceDataRaw(t, r.Schema, map[string]interface{}{
+		"ignore_metadata": true,
+	})
+
+	if !diffSuppress("as3_json", old, new, d) {
+		t.Error("Expected metadata-only diff to be suppressed when ignore_metadata=true")
+	}
+}
+
+func TestDiffSuppressFunc_IgnoreMetadataTrue_RealDiff(t *testing.T) {
+	diffSuppress := getDiffSuppressFunc()
+
+	// Real user config change beyond metadata
+	old := `{"class":"AS3","declaration":{"class":"ADC","schemaVersion":"3.0.0","updateMode":"selective","MyTenant":{"class":"Tenant","app":{"class":"Application"}}}}`
+	new := `{"class":"AS3","declaration":{"class":"ADC","MyTenant":{"class":"Tenant","app":{"class":"Application","pool":{"class":"Pool"}}}}}`
+
+	r := resourceBigipAs3()
+	d := schema.TestResourceDataRaw(t, r.Schema, map[string]interface{}{
+		"ignore_metadata": true,
+	})
+
+	if diffSuppress("as3_json", old, new, d) {
+		t.Error("Expected real config diff to NOT be suppressed even when ignore_metadata=true")
+	}
+}
+
+func TestDiffSuppressFunc_IgnoreMetadataTrue_CommonNotUserDefined(t *testing.T) {
+	diffSuppress := getDiffSuppressFunc()
+
+	// old has Common added by BIG-IP, new does NOT define Common
+	old := `{"class":"AS3","declaration":{"class":"ADC","schemaVersion":"3.0.0","Common":{"class":"Tenant","Shared":{"class":"Application"}},"MyTenant":{"class":"Tenant"}}}`
+	new := `{"class":"AS3","declaration":{"class":"ADC","MyTenant":{"class":"Tenant"}}}`
+
+	r := resourceBigipAs3()
+	d := schema.TestResourceDataRaw(t, r.Schema, map[string]interface{}{
+		"ignore_metadata": true,
+	})
+
+	if !diffSuppress("as3_json", old, new, d) {
+		t.Error("Expected auto-created Common to be suppressed when user did not define it and ignore_metadata=true")
+	}
+}
+
+func TestDiffSuppressFunc_IgnoreMetadataTrue_CommonUserDefined(t *testing.T) {
+	diffSuppress := getDiffSuppressFunc()
+
+	// Both old and new define Common, but with different content
+	old := `{"class":"AS3","declaration":{"class":"ADC","schemaVersion":"3.0.0","Common":{"class":"Tenant","Shared":{"class":"Application","myPool":{"class":"Pool","members":[{"servicePort":80}]}}},"MyTenant":{"class":"Tenant"}}}`
+	new := `{"class":"AS3","declaration":{"class":"ADC","Common":{"class":"Tenant","Shared":{"class":"Application","myPool":{"class":"Pool","members":[{"servicePort":8080}]}}},"MyTenant":{"class":"Tenant"}}}`
+
+	r := resourceBigipAs3()
+	d := schema.TestResourceDataRaw(t, r.Schema, map[string]interface{}{
+		"ignore_metadata": true,
+	})
+
+	if diffSuppress("as3_json", old, new, d) {
+		t.Error("Expected user-defined Common changes to NOT be suppressed even with ignore_metadata=true")
+	}
+}
+
+func TestDiffSuppressFunc_IgnoreMetadataFalse_MetadataOnlyDiff(t *testing.T) {
+	diffSuppress := getDiffSuppressFunc()
+
+	// Only metadata differs — but ignore_metadata is false, so strict mode should detect it
+	old := `{"class":"AS3","declaration":{"class":"ADC","schemaVersion":"3.50.0","id":"autogen_id","updateMode":"selective","MyTenant":{"class":"Tenant"}}}`
+	new := `{"class":"AS3","declaration":{"class":"ADC","MyTenant":{"class":"Tenant"}}}`
+
+	r := resourceBigipAs3()
+	d := schema.TestResourceDataRaw(t, r.Schema, map[string]interface{}{
+		"ignore_metadata": false,
+	})
+
+	if diffSuppress("as3_json", old, new, d) {
+		t.Error("Expected metadata-only diff to NOT be suppressed when ignore_metadata=false (strict mode)")
+	}
+}

--- a/docs/resources/bigip_as3.md
+++ b/docs/resources/bigip_as3.md
@@ -144,7 +144,7 @@ resource "bigip_as3" "as3-example1" {
 
 * `application_list` - (Optional) - List of applications currently deployed on the Big-Ip
 
-* `ignore_metadata` - (Optional) Set True if you want to ignore metadata changes during update. By default it is set to false
+* `ignore_metadata` - (Optional, Default: false) Set to true to ignore AS3 metadata fields (`updateMode`, `schemaVersion`, `id`, `label`, `remark`, `persist`) when comparing the stored declaration against the desired state. When enabled, differences in these metadata fields (which BIG-IP AS3 may add or modify automatically) will not trigger an update. If the user does not define a `Common` tenant in their declaration, the auto-created `Common` partition is also excluded from comparison. If the user defines `Common` in their declaration, changes to it will be detected normally.
 
 * `as3_example1.json` - Example  AS3 Declarative JSON file with single tenant
 
@@ -362,7 +362,7 @@ resource "bigip_as3" "as3_declare" {
 
 ### Common Attributes
 
-- `ignore_metadata` - (Optional, Default: false) Set to true to ignore AS3 metadata when comparing.
+- `ignore_metadata` - (Optional, Default: false) Set to true to ignore AS3 metadata fields (`updateMode`, `schemaVersion`, `id`, `label`, `remark`, `persist`) when comparing the stored declaration against the desired state. When enabled, differences in these metadata fields (which BIG-IP AS3 may add or modify automatically) will not trigger an update. If the user does not define a `Common` tenant in their declaration, the auto-created `Common` partition is also excluded from comparison. If the user defines `Common` in their declaration, changes to it will be detected normally.
 - `tenant_filter` - (Optional) Filters tenants from AS3 declaration.
 - `tenant_name` - (Computed) The tenant name used.
 - `per_app_mode` - (Computed) Whether the AS3 was posted in per-app mode.


### PR DESCRIPTION
## Summary

Fixes the `ignore_metadata` behavior in `bigip_as3` to correctly distinguish
between AS3 metadata and user-defined configuration, particularly for the
Common partition.

## Problem

When `ignore_metadata = true`, the `DiffSuppressFunc` unconditionally deleted
the `Common` key from both the old (state) and new (desired) declarations.
This meant that any user-defined configuration in the Common partition was
silently ignored on subsequent applies — Terraform would never detect changes.

Additionally, the control flow when `ignore_metadata = false` was convoluted
and could return `true` (suppress diff) in unreachable edge cases.

## Solution

- Moved all metadata stripping logic to only execute when `ignore_metadata = true`
- When `ignore_metadata = false`, any difference immediately returns `false`
  (triggers plan/apply) — this is now the simple, expected strict mode
- Common partition is only stripped from comparison when the user did NOT
  define it in their declaration (handles BIG-IP AS3 auto-creating Common
  for shared objects)
- Extracted a `stripAS3Metadata` helper function to eliminate duplication and
  the error-prone pattern of deleting map keys during iteration
- Removed the erroneous `for range rec` loop that ran deletes once per map
  entry instead of once total
- Updated the inline schema description for `ignore_metadata` to match the
  documentation

## Testing

Added 7 unit tests covering:
1. Identical JSON → suppressed (both modes)
2. `ignore_metadata=false` with real diff → not suppressed
3. `ignore_metadata=true` with metadata-only diff → suppressed
4. `ignore_metadata=true` with real config diff → not suppressed
5. `ignore_metadata=true`, Common not user-defined → auto-Common suppressed
6. `ignore_metadata=true`, Common user-defined → Common changes detected
7. `ignore_metadata=false` with metadata-only diff → not suppressed (strict mode regression test)

## Documentation

Updated `docs/resources/bigip_as3.md` to clearly explain:
- Which fields are considered "metadata" (`updateMode`, `schemaVersion`, `id`, `label`, `remark`, `persist`)
- The Common partition behavior (only excluded if not in user's declaration)

## Resolves
AUTOTOOL-5279
